### PR TITLE
:racehorse: Enable thread safe rendering of cached reports

### DIFF
--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
@@ -1,0 +1,40 @@
+/*
+ * DynamicReports - Free Java reporting library for creating reports dynamically
+ *
+ * Copyright (C) 2010 - 2018 Ricardo Mariaca and the Dynamic Reports Contributors
+ * http://www.dynamicreports.org
+ *
+ * This file is part of DynamicReports.
+ *
+ * DynamicReports is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * DynamicReports is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * DynamicReports. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.sf.dynamicreports.jasper.base;
+
+/**
+ * Simple, default implementation of {@link JasperScriptletManager}.
+ */
+public class DefaultJasperScriptletManager implements JasperScriptletManager {
+
+  private JasperScriptlet jasperScriptlet;
+
+  @Override
+  public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+    this.jasperScriptlet = jasperScriptlet;
+  }
+
+  @Override
+  public JasperScriptlet getJasperScriptlet() {
+    return jasperScriptlet;
+  }
+
+}

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
@@ -6,20 +6,27 @@
  *
  * This file is part of DynamicReports.
  *
- * DynamicReports is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * DynamicReports is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * DynamicReports is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * DynamicReports is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with DynamicReports. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * DynamicReports. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package net.sf.dynamicreports.jasper.base;
+
+import static java.lang.Boolean.TRUE;
+import static net.sf.dynamicreports.jasper.base.JasperScriptletManager.USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression;
 import net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression;
@@ -28,278 +35,341 @@ import net.sf.dynamicreports.jasper.constant.ValueType;
 import net.sf.dynamicreports.report.constant.Constants;
 import net.sf.dynamicreports.report.definition.DRICustomValues;
 import net.sf.dynamicreports.report.definition.chart.DRIChartCustomizer;
+
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
- * <p>JasperCustomValues class.</p>
+ * <p>
+ * JasperCustomValues class.
+ * </p>
  *
  * @author edwin.njeru
  * @version $Id: $Id
  */
 public class JasperCustomValues implements DRICustomValues {
-    private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
+  private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    private Map<String, ValueType> valueTypes;
-    private Map<String, DRIDesignSimpleExpression> simpleExpressions;
-    private Map<String, DRIDesignComplexExpression> complexExpressions;
-    private Map<String, List<DRIChartCustomizer>> chartCustomizers;
-    private Map<String, Object> systemValues;
-    private JasperScriptlet jasperScriptlet;
-    private Integer startPageNumber;
-    private Map<String, JasperTocHeading> tocHeadings;
-    private Integer subreportWidth;
+  private Map<String, ValueType> valueTypes;
+  private Map<String, DRIDesignSimpleExpression> simpleExpressions;
+  private Map<String, DRIDesignComplexExpression> complexExpressions;
+  private Map<String, List<DRIChartCustomizer>> chartCustomizers;
+  private Map<String, Object> systemValues;
+  private Integer startPageNumber;
+  private Map<String, JasperTocHeading> tocHeadings;
+  private Integer subreportWidth;
+  private transient JasperScriptletManager scriptletManager;
 
-    /**
-     * <p>Constructor for JasperCustomValues.</p>
+  /**
+   * <p>
+   * Constructor for JasperCustomValues.
+   * </p>
+   */
+  public JasperCustomValues(Properties properties) {
+    init(properties);
+  }
+
+  private void init(Properties properties) {
+    valueTypes = new HashMap<>();
+    simpleExpressions = new HashMap<>();
+    complexExpressions = new HashMap<>();
+    chartCustomizers = new HashMap<>();
+    systemValues = new HashMap<>();
+    scriptletManager = createScriptletManager(properties);
+  }
+
+  private JasperScriptletManager createScriptletManager(Properties properties) {
+    String useThreadSafeScriptletManagerPropertyValue =
+        properties.getProperty(USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY);
+    if (TRUE.toString().equalsIgnoreCase(useThreadSafeScriptletManagerPropertyValue)) {
+      return new ThreadSafeJasperScriptletManager();
+    }
+    return new DefaultJasperScriptletManager();
+  }
+
+  /**
+   * <p>
+   * addSimpleExpression.
+   * </p>
+   *
+   * @param simpleExpression a
+   *        {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression}
+   *        object.
+   */
+  public void addSimpleExpression(DRIDesignSimpleExpression simpleExpression) {
+    simpleExpressions.put(simpleExpression.getName(), simpleExpression);
+    addValueType(simpleExpression.getName(), ValueType.SIMPLE_EXPRESSION);
+  }
+
+  /**
+   * <p>
+   * addComplexExpression.
+   * </p>
+   *
+   * @param complexExpression a
+   *        {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression}
+   *        object.
+   */
+  public void addComplexExpression(DRIDesignComplexExpression complexExpression) {
+    complexExpressions.put(complexExpression.getName(), complexExpression);
+    addValueType(complexExpression.getName(), ValueType.COMPLEX_EXPRESSION);
+  }
+
+  /**
+   * <p>
+   * addChartCustomizers.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @param chartCustomizers a {@link java.util.List} object.
+   */
+  public void addChartCustomizers(String name, List<DRIChartCustomizer> chartCustomizers) {
+    this.chartCustomizers.put(name, chartCustomizers);
+  }
+
+  /**
+   * <p>
+   * addValueType.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @param valueType a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
+   */
+  public void addValueType(String name, ValueType valueType) {
+    /*
+     * if (valueTypes.containsKey(name)) { throw new JasperDesignException("Duplicate value name \""
+     * + name + "\""); }
      */
-    public JasperCustomValues() {
-        init();
-    }
+    valueTypes.put(name, valueType);
+  }
 
-    private void init() {
-        valueTypes = new HashMap<>();
-        simpleExpressions = new HashMap<>();
-        complexExpressions = new HashMap<>();
-        chartCustomizers = new HashMap<>();
-        systemValues = new HashMap<>();
-    }
+  /**
+   * <p>
+   * getValueType.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
+   */
+  protected ValueType getValueType(String name) {
+    return valueTypes.get(name);
+  }
 
-    /**
-     * <p>addSimpleExpression.</p>
-     *
-     * @param simpleExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression} object.
-     */
-    public void addSimpleExpression(DRIDesignSimpleExpression simpleExpression) {
-        simpleExpressions.put(simpleExpression.getName(), simpleExpression);
-        addValueType(simpleExpression.getName(), ValueType.SIMPLE_EXPRESSION);
-    }
+  /**
+   * <p>
+   * getSimpleExpression.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression}
+   *         object.
+   */
+  protected DRIDesignSimpleExpression getSimpleExpression(String name) {
+    return simpleExpressions.get(name);
+  }
 
-    /**
-     * <p>addComplexExpression.</p>
-     *
-     * @param complexExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression} object.
-     */
-    public void addComplexExpression(DRIDesignComplexExpression complexExpression) {
-        complexExpressions.put(complexExpression.getName(), complexExpression);
-        addValueType(complexExpression.getName(), ValueType.COMPLEX_EXPRESSION);
-    }
+  /**
+   * <p>
+   * getComplexExpression.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression}
+   *         object.
+   */
+  protected DRIDesignComplexExpression getComplexExpression(String name) {
+    return complexExpressions.get(name);
+  }
 
-    /**
-     * <p>addChartCustomizers.</p>
-     *
-     * @param name             a {@link java.lang.String} object.
-     * @param chartCustomizers a {@link java.util.List} object.
-     */
-    public void addChartCustomizers(String name, List<DRIChartCustomizer> chartCustomizers) {
-        this.chartCustomizers.put(name, chartCustomizers);
-    }
+  /**
+   * <p>
+   * Getter for the field <code>chartCustomizers</code>.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link java.util.List} object.
+   */
+  protected List<DRIChartCustomizer> getChartCustomizers(String name) {
+    return chartCustomizers.get(name);
+  }
 
-    /**
-     * <p>addValueType.</p>
-     *
-     * @param name      a {@link java.lang.String} object.
-     * @param valueType a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
-     */
-    public void addValueType(String name, ValueType valueType) {
-		/*if (valueTypes.containsKey(name)) {
-			throw new JasperDesignException("Duplicate value name \"" + name + "\"");
-		}*/
-        valueTypes.put(name, valueType);
+  /**
+   * <p>
+   * isEmpty.
+   * </p>
+   *
+   * @return a boolean.
+   */
+  public boolean isEmpty() {
+    if (!simpleExpressions.isEmpty()) {
+      return false;
     }
+    if (!complexExpressions.isEmpty()) {
+      return false;
+    }
+    if (!chartCustomizers.isEmpty()) {
+      return false;
+    }
+    return true;
+  }
 
-    /**
-     * <p>getValueType.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
-     */
-    protected ValueType getValueType(String name) {
-        return valueTypes.get(name);
-    }
+  /**
+   * <p>
+   * getValue.
+   * </p>
+   *
+   * @param valueName a {@link java.lang.String} object.
+   * @return a {@link java.lang.Object} object.
+   */
+  public Object getValue(String valueName) {
+    return scriptletManager.getJasperScriptlet().getValue(valueName);
+       
+  }
 
-    /**
-     * <p>getSimpleExpression.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression} object.
-     */
-    protected DRIDesignSimpleExpression getSimpleExpression(String name) {
-        return simpleExpressions.get(name);
-    }
+  /**
+   * <p>
+   * getValue.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @param values an array of {@link java.lang.Object} objects.
+   * @return a {@link java.lang.Object} object.
+   */
+  public Object getValue(String name, Object[] values) {
+    return scriptletManager.getJasperScriptlet().getValue(name, values);
+  }
 
-    /**
-     * <p>getComplexExpression.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression} object.
-     */
-    protected DRIDesignComplexExpression getComplexExpression(String name) {
-        return complexExpressions.get(name);
-    }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setSystemValue(String name, Object value) {
+    systemValues.put(name, value);
+  }
 
-    /**
-     * <p>Getter for the field <code>chartCustomizers</code>.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link java.util.List} object.
-     */
-    protected List<DRIChartCustomizer> getChartCustomizers(String name) {
-        return chartCustomizers.get(name);
-    }
+  /**
+   * <p>
+   * getSystemValue.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link java.lang.Object} object.
+   */
+  protected Object getSystemValue(String name) {
+    return systemValues.get(name);
+  }
 
-    /**
-     * <p>isEmpty.</p>
-     *
-     * @return a boolean.
-     */
-    public boolean isEmpty() {
-        if (!simpleExpressions.isEmpty()) {
-            return false;
-        }
-        if (!complexExpressions.isEmpty()) {
-            return false;
-        }
-        if (!chartCustomizers.isEmpty()) {
-            return false;
-        }
-        return true;
-    }
+  /**
+   * <p>
+   * Getter for the field <code>jasperScriptlet</code>.
+   * </p>
+   *
+   * @return a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
+   */
+  protected JasperScriptlet getJasperScriptlet() {
+    return scriptletManager.getJasperScriptlet();
+  }
 
-    /**
-     * <p>getValue.</p>
-     *
-     * @param valueName a {@link java.lang.String} object.
-     * @return a {@link java.lang.Object} object.
-     */
-    public Object getValue(String valueName) {
-        return jasperScriptlet.getValue(valueName);
-    }
+  /**
+   * <p>
+   * Setter for the field <code>jasperScriptlet</code>.
+   * </p>
+   *
+   * @param jasperScriptlet a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
+   */
+  protected void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+    scriptletManager.setJasperScriptlet(jasperScriptlet);
+  }
 
-    /**
-     * <p>getValue.</p>
-     *
-     * @param name   a {@link java.lang.String} object.
-     * @param values an array of {@link java.lang.Object} objects.
-     * @return a {@link java.lang.Object} object.
-     */
-    public Object getValue(String name, Object[] values) {
-        return jasperScriptlet.getValue(name, values);
-    }
+  /**
+   * <p>
+   * Getter for the field <code>startPageNumber</code>.
+   * </p>
+   *
+   * @return a {@link java.lang.Integer} object.
+   */
+  public Integer getStartPageNumber() {
+    return startPageNumber;
+  }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setSystemValue(String name, Object value) {
-        systemValues.put(name, value);
-    }
+  /**
+   * <p>
+   * Setter for the field <code>startPageNumber</code>.
+   * </p>
+   *
+   * @param startPageNumber a {@link java.lang.Integer} object.
+   */
+  public void setStartPageNumber(Integer startPageNumber) {
+    this.startPageNumber = startPageNumber;
+  }
 
-    /**
-     * <p>getSystemValue.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link java.lang.Object} object.
-     */
-    protected Object getSystemValue(String name) {
-        return systemValues.get(name);
-    }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void addTocHeading(int level, String id, String text, Object customValue) {
+    JasperTocHeading heading = new JasperTocHeading();
+    heading.setLevel(level);
+    heading.setText(text);
+    heading.setReference(id);
+    heading.setCustomValue(customValue);
+    tocHeadings.put(id, heading);
+  }
 
-    /**
-     * <p>Getter for the field <code>jasperScriptlet</code>.</p>
-     *
-     * @return a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
-     */
-    protected JasperScriptlet getJasperScriptlet() {
-        return jasperScriptlet;
-    }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<String, JasperTocHeading> getTocHeadings() {
+    return tocHeadings;
+  }
 
-    /**
-     * <p>Setter for the field <code>jasperScriptlet</code>.</p>
-     *
-     * @param jasperScriptlet a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
-     */
-    protected void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
-        this.jasperScriptlet = jasperScriptlet;
-    }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setTocHeadings(Map<String, JasperTocHeading> tocHeadings) {
+    this.tocHeadings = tocHeadings;
+  }
 
-    /**
-     * <p>Getter for the field <code>startPageNumber</code>.</p>
-     *
-     * @return a {@link java.lang.Integer} object.
-     */
-    public Integer getStartPageNumber() {
-        return startPageNumber;
-    }
+  /**
+   * <p>
+   * Getter for the field <code>subreportWidth</code>.
+   * </p>
+   *
+   * @return a {@link java.lang.Integer} object.
+   */
+  public Integer getSubreportWidth() {
+    return subreportWidth;
+  }
 
-    /**
-     * <p>Setter for the field <code>startPageNumber</code>.</p>
-     *
-     * @param startPageNumber a {@link java.lang.Integer} object.
-     */
-    public void setStartPageNumber(Integer startPageNumber) {
-        this.startPageNumber = startPageNumber;
-    }
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setSubreportWidth(Integer subreportWidth) {
+    this.subreportWidth = subreportWidth;
+  }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addTocHeading(int level, String id, String text, Object customValue) {
-        JasperTocHeading heading = new JasperTocHeading();
-        heading.setLevel(level);
-        heading.setText(text);
-        heading.setReference(id);
-        heading.setCustomValue(customValue);
-        tocHeadings.put(id, heading);
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    StringBuilder result = new StringBuilder();
+    for (String name : valueTypes.keySet()) {
+      result.append(valueTypes.get(name).name() + ":" + name);
+      result.append(", ");
     }
+    return "{" + StringUtils.removeEnd(result.toString(), ", ") + "}";
+  }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Map<String, JasperTocHeading> getTocHeadings() {
-        return tocHeadings;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setTocHeadings(Map<String, JasperTocHeading> tocHeadings) {
-        this.tocHeadings = tocHeadings;
-    }
-
-    /**
-     * <p>Getter for the field <code>subreportWidth</code>.</p>
-     *
-     * @return a {@link java.lang.Integer} object.
-     */
-    public Integer getSubreportWidth() {
-        return subreportWidth;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setSubreportWidth(Integer subreportWidth) {
-        this.subreportWidth = subreportWidth;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        StringBuilder result = new StringBuilder();
-        for (String name : valueTypes.keySet()) {
-            result.append(valueTypes.get(name).name() + ":" + name);
-            result.append(", ");
-        }
-        return "{" + StringUtils.removeEnd(result.toString(), ", ") + "}";
-    }
+  /**
+   * Getter for testing purposes.
+   * @return the {@link JasperScriptletManager}
+   */
+  JasperScriptletManager getScriptletManager() {
+    return scriptletManager;
+  }
+  
+  
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperReportDesign.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperReportDesign.java
@@ -78,7 +78,7 @@ public class JasperReportDesign implements Serializable {
         this.design = (JasperDesign) report.getTemplateDesign().getDesign();
         this.tableOfContents = report.isTableOfContents();
         this.tableOfContentsCustomizer = report.getTableOfContentsCustomizer();
-        this.customValues = new JasperCustomValues();
+        this.customValues = new JasperCustomValues(report.getProperties());
         this.parameters = new HashMap<String, Object>();
     }
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
@@ -1,0 +1,45 @@
+/*
+ * DynamicReports - Free Java reporting library for creating reports dynamically
+ *
+ * Copyright (C) 2010 - 2018 Ricardo Mariaca and the Dynamic Reports Contributors
+ * http://www.dynamicreports.org
+ *
+ * This file is part of DynamicReports.
+ *
+ * DynamicReports is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * DynamicReports is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * DynamicReports. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.sf.dynamicreports.jasper.base;
+
+/**
+ * Interface for managers of {@link JasperScriptlet} used in {@link JasperCustomValues}.
+ */
+public interface JasperScriptletManager {
+
+  /** Property key used for selecting thread safe implementation. */
+  public static final String USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY =
+      "net.sf.dynamicreports.useThreadSafeScriptletManager";
+
+  /**
+   * Setter for the {@link JasperScriptlet} instance.
+   * 
+   * @param jasperScriptlet the {@link JasperScriptlet} instance to set
+   */
+  void setJasperScriptlet(JasperScriptlet jasperScriptlet);
+
+  /**
+   * Getter for the {@link JasperScriptlet} instance.
+   * 
+   * @return the set {@link JasperScriptlet} instance
+   */
+  JasperScriptlet getJasperScriptlet();
+}

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
@@ -1,0 +1,45 @@
+/*
+ * DynamicReports - Free Java reporting library for creating reports dynamically
+ *
+ * Copyright (C) 2010 - 2018 Ricardo Mariaca and the Dynamic Reports Contributors
+ * http://www.dynamicreports.org
+ *
+ * This file is part of DynamicReports.
+ *
+ * DynamicReports is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * DynamicReports is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * DynamicReports. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.sf.dynamicreports.jasper.base;
+
+import net.sf.jasperreports.engine.JasperCompileManager;
+
+/**
+ * Thread safe implementation of {@link JasperCompileManager} used for filling
+ * cached reports concurrently. Note: use of this class can lead to memory leaks
+ * if the threads starting the report fill are not terminated properly.
+ */
+public class ThreadSafeJasperScriptletManager implements JasperScriptletManager {
+
+  private ThreadLocal<JasperScriptlet> threadLocalScriptlet = new ThreadLocal<>();
+  
+  @Override
+  public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+    threadLocalScriptlet.set(jasperScriptlet);
+
+  }
+
+  @Override
+  public JasperScriptlet getJasperScriptlet() {
+    return threadLocalScriptlet.get();
+  }
+
+}

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/DatasetTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/DatasetTransform.java
@@ -82,7 +82,7 @@ public class DatasetTransform {
         if (dataset.getQuery() != null) {
             jrDataset.setQuery(accessor.getReportTransform().query(dataset.getQuery()));
         }
-        JasperCustomValues customValues = new JasperCustomValues();
+        JasperCustomValues customValues = new JasperCustomValues(accessor.getReport().getProperties());
         DatasetExpressionTransform datasetExpressionTransform = new DatasetExpressionTransform(dataset, jrDataset, customValues);
         datasetExpressionTransform.transform();
         datasetExpressions.put(dataset, datasetExpressionTransform);

--- a/dynamicreports-core/src/test/java/net/sf/dynamicreports/jasper/base/JasperCustomValuesTest.java
+++ b/dynamicreports-core/src/test/java/net/sf/dynamicreports/jasper/base/JasperCustomValuesTest.java
@@ -1,0 +1,50 @@
+package net.sf.dynamicreports.jasper.base;
+
+import static net.sf.dynamicreports.jasper.base.JasperScriptletManager.USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY;
+
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link JasperCustomValues}.
+ */
+public class JasperCustomValuesTest {
+
+  private JasperScriptlet scriptlet = new JasperScriptlet();
+  
+  @Test
+  public void shouldUseDefaultScriptletManager() {
+    JasperCustomValues cut = createClassUnderTest(false);
+    Assert.assertTrue(cut.getScriptletManager() instanceof DefaultJasperScriptletManager);
+  }
+  
+  @Test
+  public void shouldUseThreadSafeScriptleManagerIfPropertySet() {
+    JasperCustomValues cut = createClassUnderTest(true);
+    Assert.assertTrue(cut.getScriptletManager() instanceof ThreadSafeJasperScriptletManager);
+  }
+
+  @Test
+  public void shouldSetScriptletWithDefaultManager() {
+    JasperCustomValues cut = createClassUnderTest(false);
+    cut.setJasperScriptlet(scriptlet);
+    Assert.assertEquals(scriptlet, cut.getJasperScriptlet());
+  }
+  
+  @Test
+  public void shouldSetScriptletWithThreadSafeManager() {
+    JasperCustomValues cut = createClassUnderTest(true);
+    cut.setJasperScriptlet(scriptlet);
+    Assert.assertEquals(scriptlet, cut.getJasperScriptlet());    
+  }
+  
+  private JasperCustomValues createClassUnderTest(boolean useThreadSafeManager) {
+    Properties properties = new Properties();
+    if (useThreadSafeManager) {
+      properties.setProperty(USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY, "true");
+    }
+    return new JasperCustomValues(properties);
+  }
+}


### PR DESCRIPTION
This commit is related to
https://github.com/dynamicreports/dynamicreports/issues/26
By using JasperScriptletManager with two implementations in
JasperCustomValues, a thread safe variant to manage the
JasperScriptlet can be selected by setting a report property.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature, performance improvement: By setting the report property JasperScriptletManager.USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY a cached report can be filled concurrently. This allows to use big and complex reports without compiling them for every fill request.


* **What is the current behavior?** (You can also link to an open issue here)
Concurrent filling of cached reports does not work, because the JasperScriptlet is changed in JasperCustomValues by concurrent fill threads.


* **What is the new behavior (if this is a feature change)?**
A thread safe variant of JasperScriptletManager is used in JasperCustomValues if the mentioned property has been set. This variant uses ThreadLocal to access the JasperScriptlet. Otherwise a simple default implementation is used that accesses the JasperScriptlet from a private member variable. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**: none
