### PR TITLE
:bug: ReportUtils.generateUniqueName(String) is not thread safe

### DIFF
--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
@@ -6,102 +6,123 @@
  *
  * This file is part of DynamicReports.
  *
- * DynamicReports is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * DynamicReports is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * DynamicReports is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * DynamicReports is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with DynamicReports. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * DynamicReports. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package net.sf.dynamicreports.report;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import net.sf.dynamicreports.report.constant.Calculation;
 
-import java.lang.reflect.ParameterizedType;
-
 /**
- * <p>ReportUtils class.</p>
+ * <p>
+ * ReportUtils class.
+ * </p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
 public class ReportUtils {
-    private static int counter = 0;
+  private static final Lock LOCK = new ReentrantLock();
+  private static int counter = 0;
 
-    /**
-     * <p>generateUniqueName.</p>
-     *
-     * @param name a {@link java.lang.String} object.
-     * @return a {@link java.lang.String} object.
-     */
-    public static String generateUniqueName(String name) {
-        if (counter == Integer.MAX_VALUE) {
-            counter = 0;
-        }
-        return name + "_" + counter++ + "_";
+  /**
+   * <p>
+   * generateUniqueName.
+   * </p>
+   *
+   * @param name a {@link java.lang.String} object.
+   * @return a {@link java.lang.String} object.
+   */
+  public static String generateUniqueName(String name) {
+    try {
+      LOCK.lock();
+      return generateName(name);
+    } finally {
+      LOCK.unlock();
     }
+  }
 
-    /**
-     * <p>getVariableValueClass.</p>
-     *
-     * @param calculation a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param valueClass  a {@link java.lang.Class} object.
-     * @return a {@link java.lang.Class} object.
-     */
-    public static Class<?> getVariableValueClass(Calculation calculation, Class<?> valueClass) {
-        if (calculation.equals(Calculation.COUNT) || calculation.equals(Calculation.DISTINCT_COUNT)) {
-            return Long.class;
-        }
-        if (calculation.equals(Calculation.AVERAGE) || calculation.equals(Calculation.STANDARD_DEVIATION) || calculation.equals(Calculation.VARIANCE)) {
-            return Number.class;
-        }
-        return valueClass;
+  /**
+   * <p>
+   * getVariableValueClass.
+   * </p>
+   *
+   * @param calculation a {@link net.sf.dynamicreports.report.constant.Calculation} object.
+   * @param valueClass a {@link java.lang.Class} object.
+   * @return a {@link java.lang.Class} object.
+   */
+  public static Class<?> getVariableValueClass(Calculation calculation, Class<?> valueClass) {
+    if (calculation.equals(Calculation.COUNT) || calculation.equals(Calculation.DISTINCT_COUNT)) {
+      return Long.class;
     }
+    if (calculation.equals(Calculation.AVERAGE)
+        || calculation.equals(Calculation.STANDARD_DEVIATION)
+        || calculation.equals(Calculation.VARIANCE)) {
+      return Number.class;
+    }
+    return valueClass;
+  }
 
-    /**
-     * <p>getGenericClass.</p>
-     *
-     * @param object a {@link java.lang.Object} object.
-     * @param index  a int.
-     * @return a {@link java.lang.Class} object.
-     */
-    public static Class<?> getGenericClass(Object object, int index) {
-        ParameterizedType genericSuperclass = getParameterizedType(object.getClass());
-        if (genericSuperclass == null) {
-            return String.class;
-        }
-        Class<?> rawType = getRawType(genericSuperclass.getActualTypeArguments()[index]);
-        if (rawType == null) {
-            return String.class;
-        }
-        return rawType;
+  /**
+   * <p>
+   * getGenericClass.
+   * </p>
+   *
+   * @param object a {@link java.lang.Object} object.
+   * @param index a int.
+   * @return a {@link java.lang.Class} object.
+   */
+  public static Class<?> getGenericClass(Object object, int index) {
+    ParameterizedType genericSuperclass = getParameterizedType(object.getClass());
+    if (genericSuperclass == null) {
+      return String.class;
     }
+    Class<?> rawType = getRawType(genericSuperclass.getActualTypeArguments()[index]);
+    if (rawType == null) {
+      return String.class;
+    }
+    return rawType;
+  }
 
-    private static ParameterizedType getParameterizedType(Class<?> classs) {
-        if (classs == null) {
-            return null;
-        }
-        if (classs.getGenericSuperclass() instanceof ParameterizedType) {
-            return (ParameterizedType) classs.getGenericSuperclass();
-        }
-        return getParameterizedType((Class<?>) classs.getGenericSuperclass());
+  private static ParameterizedType getParameterizedType(Class<?> classs) {
+    if (classs == null) {
+      return null;
     }
+    if (classs.getGenericSuperclass() instanceof ParameterizedType) {
+      return (ParameterizedType) classs.getGenericSuperclass();
+    }
+    return getParameterizedType((Class<?>) classs.getGenericSuperclass());
+  }
 
-    private static Class<?> getRawType(Object typeArgument) {
-        if (typeArgument instanceof ParameterizedType) {
-            return getRawType(((ParameterizedType) typeArgument).getRawType());
-        } else {
-            if (typeArgument instanceof Class<?>) {
-                return (Class<?>) typeArgument;
-            } else {
-                return null;
-            }
-        }
+  private static Class<?> getRawType(Object typeArgument) {
+    if (typeArgument instanceof ParameterizedType) {
+      return getRawType(((ParameterizedType) typeArgument).getRawType());
+    } else {
+      if (typeArgument instanceof Class<?>) {
+        return (Class<?>) typeArgument;
+      } else {
+        return null;
+      }
     }
+  }
+  
+  private static String generateName(String name) {
+    if (counter == Integer.MAX_VALUE) {
+      counter = 0;
+    }
+    return name + "_" + counter++ + "_";
+  }
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
@@ -97,6 +97,15 @@ public class ReportUtils {
     return rawType;
   }
 
+  /**
+   * Setter for testing purposes only.
+   * 
+   * @param counter the counter value
+   */
+  static void setCounter(int counter) {
+    ReportUtils.counter = counter;
+  }
+
   private static ParameterizedType getParameterizedType(Class<?> classs) {
     if (classs == null) {
       return null;
@@ -118,7 +127,7 @@ public class ReportUtils {
       }
     }
   }
-  
+
   private static String generateName(String name) {
     if (counter == Integer.MAX_VALUE) {
       counter = 0;

--- a/dynamicreports-core/src/test/java/net/sf/dynamicreports/report/ReportUtilsTest.java
+++ b/dynamicreports-core/src/test/java/net/sf/dynamicreports/report/ReportUtilsTest.java
@@ -1,0 +1,50 @@
+package net.sf.dynamicreports.report;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ReportUtils}.
+ */
+public class ReportUtilsTest {
+
+  private static final String BASE_NAME = "any name";
+  private static final int NUMBER_OF_THREADS = 20;
+  private static final int NUMBER_OF_NAMES = 1000;
+  
+  @Test
+  public void shouldGenerateUniqueNamesConcurrently() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(NUMBER_OF_THREADS);    
+    try {
+      List<Future<String>> futureNames = submitTasks(executor);
+      assertUniqueNames(futureNames);
+    } finally {
+      executor.shutdown();
+    }
+  }
+  
+  private List<Future<String>> submitTasks(ExecutorService executor) {
+    Callable<String> task = () -> ReportUtils.generateUniqueName(BASE_NAME);
+    List<Future<String>> futureNames = new ArrayList<>();
+    IntStream.range(0, NUMBER_OF_NAMES).forEach(i -> futureNames.add(executor.submit(task)));
+    return futureNames;
+  }
+  
+  private void assertUniqueNames(List<Future<String>> futureNames) throws Exception {
+    Set<String> generatedNames = new HashSet<>();
+    for (Future<String> futureName : futureNames) {
+      generatedNames.add(futureName.get());
+    }
+    Assert.assertEquals(NUMBER_OF_NAMES, generatedNames.size());    
+  }
+}

--- a/dynamicreports-core/src/test/java/net/sf/dynamicreports/report/ReportUtilsTest.java
+++ b/dynamicreports-core/src/test/java/net/sf/dynamicreports/report/ReportUtilsTest.java
@@ -1,3 +1,4 @@
+
 package net.sf.dynamicreports.report;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -21,10 +23,15 @@ public class ReportUtilsTest {
   private static final String BASE_NAME = "any name";
   private static final int NUMBER_OF_THREADS = 20;
   private static final int NUMBER_OF_NAMES = 1000;
-  
+
+  @Before
+  public void setUp() {
+    ReportUtils.setCounter(1);
+  }
+
   @Test
   public void shouldGenerateUniqueNamesConcurrently() throws Exception {
-    ExecutorService executor = Executors.newFixedThreadPool(NUMBER_OF_THREADS);    
+    ExecutorService executor = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
     try {
       List<Future<String>> futureNames = submitTasks(executor);
       assertUniqueNames(futureNames);
@@ -32,19 +39,26 @@ public class ReportUtilsTest {
       executor.shutdown();
     }
   }
-  
+
+  @Test
+  public void shouldResetCounter() {
+    ReportUtils.setCounter(Integer.MAX_VALUE);
+    String name = ReportUtils.generateUniqueName(BASE_NAME);
+    Assert.assertTrue(name.endsWith("0_"));
+  }
+
   private List<Future<String>> submitTasks(ExecutorService executor) {
     Callable<String> task = () -> ReportUtils.generateUniqueName(BASE_NAME);
     List<Future<String>> futureNames = new ArrayList<>();
     IntStream.range(0, NUMBER_OF_NAMES).forEach(i -> futureNames.add(executor.submit(task)));
     return futureNames;
   }
-  
+
   private void assertUniqueNames(List<Future<String>> futureNames) throws Exception {
     Set<String> generatedNames = new HashSet<>();
     for (Future<String> futureName : futureNames) {
       generatedNames.add(futureName.get());
     }
-    Assert.assertEquals(NUMBER_OF_NAMES, generatedNames.size());    
+    Assert.assertEquals(NUMBER_OF_NAMES, generatedNames.size());
   }
 }


### PR DESCRIPTION
* ReportUtilsTest added to reproduce the bug.
* Added locking to affected method in ReportUtils.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
See https://github.com/dynamicreports/dynamicreports/issues/39


* **What is the new behavior (if this is a feature change)?**
See https://github.com/dynamicreports/dynamicreports/issues/39


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) no



* **Other information**: none
