### PR TITLE
:memo: :bug; wrong link in javadoc

### DIFF
--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
@@ -20,10 +20,8 @@
 
 package net.sf.dynamicreports.jasper.base;
 
-import net.sf.jasperreports.engine.JasperCompileManager;
-
 /**
- * Thread safe implementation of {@link JasperCompileManager} used for filling
+ * Thread safe implementation of {@link JasperScriptletManager} used for filling
  * cached reports concurrently. Note: use of this class can lead to memory leaks
  * if the threads starting the report fill are not terminated properly.
  */


### PR DESCRIPTION
* The link in the class comment for ThreadSafeJasperScriptletManager
  should point to JasperScriptletManager not JasperCompileManager.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is only a correction of a class comment.
