### PR TITLE
Javadoc issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 install: true
+dist: trusty
 
 jdk:
   - oraclejdk8

--- a/dynamicreports-adhoc/pom.xml
+++ b/dynamicreports-adhoc/pom.xml
@@ -26,12 +26,12 @@
             <artifactId>junit</artifactId>
         </dependency>
         <!--Remove multiple SLF4J bindings-->
-        <!--<dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
             <scope>compile</scope>
@@ -156,6 +156,7 @@
                         </executions>
                         <configuration>
                             <excludes>module-info.java</excludes>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                             <headerLocation>../src/etc/checkstyle.xml</headerLocation>
                             <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
                             <configLocation>../src/etc/checkstyle.xml</configLocation>
@@ -171,7 +172,7 @@
             </build>
         </profile>
 
-        <profile>
+        <!--<profile>
             <id>java8</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -183,7 +184,7 @@
                     <version>1.7.25</version>
                 </dependency>
             </dependencies>
-        </profile>
+        </profile>-->
 
         <profile>
             <id>java9</id>

--- a/dynamicreports-adhoc/pom.xml
+++ b/dynamicreports-adhoc/pom.xml
@@ -26,16 +26,16 @@
             <artifactId>junit</artifactId>
         </dependency>
         <!--Remove multiple SLF4J bindings-->
-        <dependency>
+        <!--<dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>compile</scope>
         </dependency>
-        <!--<dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <scope>compile</scope>
-        </dependency>
+        <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <scope>compile</scope>
+    </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -266,7 +266,7 @@
             </build>
         </profile>
 
-        <!--<profile>
+        <profile>
             <id>java8</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -278,7 +278,7 @@
                     <version>1.7.25</version>
                 </dependency>
             </dependencies>
-        </profile>-->
+        </profile>
 
         <profile>
             <id>java9</id>

--- a/dynamicreports-adhoc/pom.xml
+++ b/dynamicreports-adhoc/pom.xml
@@ -86,11 +86,6 @@
                     <encoding>${encoding}</encoding>
                 </configuration>
             </plugin>
-            <!--Check for use of legacy code-->
-            <plugin>
-                <groupId>org.gaul</groupId>
-                <artifactId>modernizer-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/dynamicreports-adhoc/pom.xml
+++ b/dynamicreports-adhoc/pom.xml
@@ -77,6 +77,105 @@
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${sourceVersion}</source>
+                    <target>${targetVersion}</target>
+                    <encoding>${encoding}</encoding>
+                </configuration>
+            </plugin>
+            <!--Check for use of legacy code-->
+            <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <!--Could run with mvn clean verify-->
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>run-checkstyle</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>module-info.java</excludes>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    <headerLocation>../src/etc/checkstyle.xml</headerLocation>
+                    <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
+                    <configLocation>../src/etc/checkstyle.xml</configLocation>
+                    <consoleOutput>${checkstyle.config.consoleOutput}</consoleOutput>
+                    <failsOnError>${checkstyle.config.failsOnError}</failsOnError>
+                    <includeResources>${checkstyle.config.includeResources}</includeResources>
+                    <includeTestResources>${checkstyle.config.includeTestResources}</includeTestResources>
+                    <includeTestSourceDirectory>${checkstyle.config.includeTestSourceDirectory}</includeTestSourceDirectory>
+                    <linkXRef>${linkXRef}</linkXRef>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <!--// TODO Use javadoc from JAVA 10 to create searcheable javadocs-->
+                    <!--<javadocExecutable>${env.JAVA_10_HOME}\bin\javadoc.exe</javadocExecutable>-->
+                    <sourceFileExcludes>
+                        <sourceFileExclude>${project.basedir}/dynamicreports-core/target</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+            <!--//TODO fix "commandline was too long error"-->
+            <!--<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            &lt;!&ndash;<goal>jdkinternals</goal>&ndash;&gt; &lt;!&ndash; verify main classes &ndash;&gt;
+                            <goal>test-jdkinternals</goal> &lt;!&ndash; verify test classes &ndash;&gt;
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>-->
         </plugins>
     </build>
 

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
@@ -93,17 +93,17 @@ public class AdhocManager {
      * <p>createReport.</p>
      * Creates a JasperReportBuilder which is subsequently set up with the {@code JRDataSource} and finaly used to create a report like shown here:
      * <pre>
-     *     {@link
+     *     {@code
      *     AdhocConfiguration configuration = new AdhocConfiguration();
-     * 		AdhocReport report = new AdhocReport();
-     * 		configuration.setReport(report);
-     * 		// configure report...
+     *      AdhocReport report = new AdhocReport();
+     *      configuration.setReport(report);
+     *      // configure report...
      *     JasperReportBuilder reportBuilder = AdhocManager.createReport(configuration.getReport());
-     * 	   reportBuilder.setDataSource(createDataSource());
-     * 	   reportBuilder.show();
+     *     reportBuilder.setDataSource(createDataSource());
+     *     reportBuilder.show();
      *     }
      * </pre>
-     * The {@link AdhocReportCustomizer} is internally provided by invocation of the {@link DefaultAdhocReportCustomizer}
+     * The {@code AdhocReportCustomizer} is internally provided by invocation of the {@link DefaultAdhocReportCustomizer}
      *
      * @param adhocReport a {@link net.sf.dynamicreports.adhoc.configuration.AdhocReport} object.
      * @return a {@link net.sf.dynamicreports.jasper.builder.JasperReportBuilder} object.
@@ -118,14 +118,14 @@ public class AdhocManager {
      * <p>createReport.</p>
      * Creates a JasperReportBuilder which is subsequently set up with the {@code JRDataSource} and finaly used to create a report like shown here:
      * <pre>
-     *     {@link
-     *     AdhocConfiguration configuration = new AdhocConfiguration();
-     * 		AdhocReport report = new AdhocReport();
-     * 		configuration.setReport(report);
-     * 		// configure report...
-     *     JasperReportBuilder reportBuilder = AdhocManager.createReport(configuration.getReport(), new ReportCustomizer());
-     * 	   reportBuilder.setDataSource(createDataSource());
-     * 	   reportBuilder.show();
+     *     {@code
+     *      AdhocConfiguration configuration = new AdhocConfiguration();
+     *      AdhocReport report = new AdhocReport();
+     *      configuration.setReport(report);
+     *      // configure report...
+     *      JasperReportBuilder reportBuilder = AdhocManager.createReport(configuration.getReport(), new ReportCustomizer());
+     *      reportBuilder.setDataSource(createDataSource());
+     *      reportBuilder.show();
      *     }
      * </pre>
      *
@@ -147,17 +147,17 @@ public class AdhocManager {
      * <pre>
      *     AdhocReport report = new AdhocReport();
      *     AdhocColumn column = new AdhocColumn();
-     * 		column.setName("item");
-     * 		report.addColumn(column);
+     *     column.setName("item");
+     *      report.addColumn(column);
      *
-     * 		column = new AdhocColumn();
-     * 		column.setName("quantity");
-     * 		report.addColumn(column);
-     * 	AdhocConfiguration configuration = new AdhocConfiguration();
-     * 	configuration.setReport(report);
+     *      column = new AdhocColumn();
+     *      column.setName("quantity");
+     *      report.addColumn(column);
+     *  AdhocConfiguration configuration = new AdhocConfiguration();
+     *  configuration.setReport(report);
      *
-     * 	// Now saving to an XML file in the system
-     * 	AdhocManager.saveConfiguration(configuration, new FileOutputStream("c:/temp/configuration.xml"));
+     *  // Now saving to an XML file in the system
+     *  AdhocManager.saveConfiguration(configuration, new FileOutputStream("c:/temp/configuration.xml"));
      * </pre>
      *
      * @param adhocConfiguration a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
@@ -182,8 +182,8 @@ public class AdhocManager {
      * <p>loadConfiguration.</p>
      * This method enables a client to read {@link AdhocConfiguration} from an {@link InputStream} The method may be applied as shown:
      * <pre>
-     *     {@link
-     * 			AdhocConfiguration loadedConfiguration = AdhocManager.loadConfiguration(new FileInputStream("c:/temp/configuration.xml"));
+     *     {@code
+     *        AdhocConfiguration loadedConfiguration = AdhocManager.loadConfiguration(new FileInputStream("c:/temp/configuration.xml"));
      *     }
      * </pre>
      *

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
@@ -27,9 +27,8 @@ import net.sf.dynamicreports.adhoc.exception.ConfigurationMarshallerException;
 import net.sf.dynamicreports.adhoc.exception.ConfigurationUnMarshallerException;
 import net.sf.dynamicreports.adhoc.report.AdhocReportCustomizer;
 import net.sf.dynamicreports.adhoc.report.DefaultAdhocReportCustomizer;
-import net.sf.dynamicreports.adhoc.transformation.AdhocToXmlTransform;
 import net.sf.dynamicreports.adhoc.transformation.IAdhocToXmlTransform;
-import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
+import net.sf.dynamicreports.adhoc.transformation.IXmlToAdhocTransform;
 import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
 import net.sf.dynamicreports.jasper.builder.JasperReportBuilder;
 import net.sf.dynamicreports.report.builder.DynamicReports;
@@ -69,14 +68,15 @@ public class AdhocManager {
     private static final Logger log = LoggerFactory.getLogger(AdhocManager.class);
     private static volatile AdhocManager INSTANCE = null;
     private final IAdhocToXmlTransform adhocToXmlTransform;
-    private final XmlToAdhocTransform xmlToAdhocTransform;
+    private final IXmlToAdhocTransform xmlToAdhocTransform;
 
-    private AdhocManager(IAdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
+    private AdhocManager(IAdhocToXmlTransform adhocToXmlTransform, IXmlToAdhocTransform xmlToAdhocTransform) {
         this.adhocToXmlTransform = adhocToXmlTransform;
         this.xmlToAdhocTransform = xmlToAdhocTransform;
     }
 
-    public static AdhocManager getInstance(IAdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
+    public static AdhocManager getInstance(IAdhocToXmlTransform adhocToXmlTransform, IXmlToAdhocTransform xmlToAdhocTransform
+    ) {
         if (INSTANCE == null) {
             synchronized (AdhocManager.class) {
                 INSTANCE = new AdhocManager(adhocToXmlTransform, xmlToAdhocTransform);

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/AdhocManager.java
@@ -28,6 +28,7 @@ import net.sf.dynamicreports.adhoc.exception.ConfigurationUnMarshallerException;
 import net.sf.dynamicreports.adhoc.report.AdhocReportCustomizer;
 import net.sf.dynamicreports.adhoc.report.DefaultAdhocReportCustomizer;
 import net.sf.dynamicreports.adhoc.transformation.AdhocToXmlTransform;
+import net.sf.dynamicreports.adhoc.transformation.IAdhocToXmlTransform;
 import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
 import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
 import net.sf.dynamicreports.jasper.builder.JasperReportBuilder;
@@ -67,15 +68,15 @@ public class AdhocManager {
 
     private static final Logger log = LoggerFactory.getLogger(AdhocManager.class);
     private static volatile AdhocManager INSTANCE = null;
-    private final AdhocToXmlTransform adhocToXmlTransform;
+    private final IAdhocToXmlTransform adhocToXmlTransform;
     private final XmlToAdhocTransform xmlToAdhocTransform;
 
-    private AdhocManager(AdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
+    private AdhocManager(IAdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
         this.adhocToXmlTransform = adhocToXmlTransform;
         this.xmlToAdhocTransform = xmlToAdhocTransform;
     }
 
-    public static AdhocManager getInstance(AdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
+    public static AdhocManager getInstance(IAdhocToXmlTransform adhocToXmlTransform, XmlToAdhocTransform xmlToAdhocTransform) {
         if (INSTANCE == null) {
             synchronized (AdhocManager.class) {
                 INSTANCE = new AdhocManager(adhocToXmlTransform, xmlToAdhocTransform);

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocAxisFormat.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocAxisFormat.java
@@ -120,6 +120,14 @@ public class AdhocAxisFormat implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getLabel() != null ? getLabel().hashCode() : 0;
+        result = 31 * result + (getLabelFont() != null ? getLabelFont().hashCode() : 0);
+        result = 31 * result + (getLabelColor() != null ? getLabelColor().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocChart.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocChart.java
@@ -324,6 +324,22 @@ public class AdhocChart extends AdhocComponent {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getType() != null ? getType().hashCode() : 0;
+        result = 31 * result + (getTitle() != null ? getTitle().hashCode() : 0);
+        result = 31 * result + (getTitleFont() != null ? getTitleFont().hashCode() : 0);
+        result = 31 * result + (getTitleColor() != null ? getTitleColor().hashCode() : 0);
+        result = 31 * result + (getShowLegend() != null ? getShowLegend().hashCode() : 0);
+        result = 31 * result + (xValue != null ? xValue.hashCode() : 0);
+        result = 31 * result + (getSeries() != null ? getSeries().hashCode() : 0);
+        result = 31 * result + (getSeriesColors() != null ? getSeriesColors().hashCode() : 0);
+        result = 31 * result + (xAxisFormat != null ? xAxisFormat.hashCode() : 0);
+        result = 31 * result + (yAxisFormat != null ? yAxisFormat.hashCode() : 0);
+        result = 31 * result + (getOrientation() != null ? getOrientation().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocChartSerie.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocChartSerie.java
@@ -213,6 +213,17 @@ public class AdhocChartSerie implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getSeries() != null ? getSeries().hashCode() : 0;
+        result = 31 * result + (xValue != null ? xValue.hashCode() : 0);
+        result = 31 * result + (yValue != null ? yValue.hashCode() : 0);
+        result = 31 * result + (zValue != null ? zValue.hashCode() : 0);
+        result = 31 * result + (getLabel() != null ? getLabel().hashCode() : 0);
+        result = 31 * result + (getProperties() != null ? getProperties().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocColumn.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocColumn.java
@@ -213,6 +213,17 @@ public class AdhocColumn implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getName() != null ? getName().hashCode() : 0;
+        result = 31 * result + (getTitle() != null ? getTitle().hashCode() : 0);
+        result = 31 * result + (getWidth() != null ? getWidth().hashCode() : 0);
+        result = 31 * result + (getStyle() != null ? getStyle().hashCode() : 0);
+        result = 31 * result + (getTitleStyle() != null ? getTitleStyle().hashCode() : 0);
+        result = 31 * result + (getProperties() != null ? getProperties().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocComponent.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocComponent.java
@@ -191,6 +191,16 @@ public class AdhocComponent implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getKey() != null ? getKey().hashCode() : 0;
+        result = 31 * result + (getStyle() != null ? getStyle().hashCode() : 0);
+        result = 31 * result + (getWidth() != null ? getWidth().hashCode() : 0);
+        result = 31 * result + (getHeight() != null ? getHeight().hashCode() : 0);
+        result = 31 * result + (getProperties() != null ? getProperties().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocConfiguration.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocConfiguration.java
@@ -97,6 +97,13 @@ public class AdhocConfiguration implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        int result = getReport() != null ? getReport().hashCode() : 0;
+        result = 31 * result + (getFilter() != null ? getFilter().hashCode() : 0);
+        return result;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocFilter.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/configuration/AdhocFilter.java
@@ -133,6 +133,11 @@ public class AdhocFilter implements Cloneable, Serializable {
         return true;
     }
 
+    @Override
+    public int hashCode() {
+        return getRestrictions() != null ? getRestrictions().hashCode() : 0;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationMarshallerException.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationMarshallerException.java
@@ -58,4 +58,12 @@ public class ConfigurationMarshallerException extends DRException {
         super(String.format("Exception encountered while marshalling the JAXBElement : %s into the outputStream : %s", element, new StreamResult(outputStream)));
     }
 
+    /**
+     * <p>Constructor for DRException.</p>
+     *
+     * @param message a {@link String} object.
+     */
+    public ConfigurationMarshallerException(String message) {
+        super(message);
+    }
 }

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationMarshallerException.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationMarshallerException.java
@@ -34,13 +34,13 @@ import java.io.OutputStream;
  * <pre>
  *     {@code
  *     try {
- * 			Marshaller marshaller = JAXBContext.newInstance(XmlAdhocConfiguration.class).createMarshaller();
- * 			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
- * 			element = new net.sf.dynamicreports.adhoc.xmlconfiguration.ObjectFactory().createConfiguration(xmlAdhocConfiguration);
- * 			marshaller.marshal(element, new StreamResult(outputStream));
- * 		} catch (JAXBException e) {
- * 			throw new ConfigurationMarshallerException(element, outputStream);
- * 		}
+ *          Marshaller marshaller = JAXBContext.newInstance(XmlAdhocConfiguration.class).createMarshaller();
+ *          marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+ *          element = new net.sf.dynamicreports.adhoc.xmlconfiguration.ObjectFactory().createConfiguration(xmlAdhocConfiguration);
+ *          marshaller.marshal(element, new StreamResult(outputStream));
+ *       } catch (JAXBException e) {
+ *         throw new ConfigurationMarshallerException(element, outputStream);
+ *       }
  *     }
  * </pre>
  * The constructor only accepts two parameters being the {@link JAXBElement} that was being marshalled and the {@link OutputStream} into which we are marshalling the element.

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationUnMarshallerException.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationUnMarshallerException.java
@@ -37,15 +37,15 @@ public class ConfigurationUnMarshallerException extends DRException {
      * <pre>
      *     {@code
      *     try {
-     * 			Unmarshaller unmarshaller = JAXBContext.newInstance(XmlAdhocConfiguration.class).createUnmarshaller();
-     * 			JAXBElement<XmlAdhocConfiguration> element = unmarshaller.unmarshal(new StreamSource(is), XmlAdhocConfiguration.class);
-     * 			XmlAdhocConfiguration xmlAdhocConfiguration = element.getValue();
-     * 			AdhocConfiguration adhocConfiguration = xmlToAdhocTransform.transform(xmlAdhocConfiguration);
-     * 			return adhocConfiguration;
-     * 		} catch (JAXBException e) {
-     * 	        // time to throw our exception
-     * 			throw new ConfigurationUnMarshallerException(is);
-     * 		}
+     *          Unmarshaller unmarshaller = JAXBContext.newInstance(XmlAdhocConfiguration.class).createUnmarshaller();
+     *          JAXBElement<XmlAdhocConfiguration> element = unmarshaller.unmarshal(new StreamSource(is), XmlAdhocConfiguration.class);
+     *          XmlAdhocConfiguration xmlAdhocConfiguration = element.getValue();
+     *          AdhocConfiguration adhocConfiguration = xmlToAdhocTransform.transform(xmlAdhocConfiguration);
+     *          return adhocConfiguration;
+     *       } catch (JAXBException e) {
+     *          // time to throw our exception
+     *          throw new ConfigurationUnMarshallerException(is);
+     *       }
      *     }
      * </pre>
      *

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationUnMarshallerException.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/exception/ConfigurationUnMarshallerException.java
@@ -55,4 +55,8 @@ public class ConfigurationUnMarshallerException extends DRException {
 
         super(String.format("Exception encountered when reading configuration from the source : %s", is));
     }
+
+    public ConfigurationUnMarshallerException(String message) {
+        super(message);
+    }
 }

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/report/DefaultAdhocReportCustomizer.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/report/DefaultAdhocReportCustomizer.java
@@ -135,7 +135,7 @@ import java.util.Map;
  *         public void customize(ReportBuilder<?> report, AdhocReport adhocReport) throws DRException {
  *            super.customize(report, adhocReport);
  *            // default report values
- * 	          report.setTemplate(Templates.reportTemplate);
+ *            report.setTemplate(Templates.reportTemplate);
  *            report.title(Templates.createTitleComponent("AdhocCustomizer"));
  *            // a fixed page footer that user cannot change, this customization is not stored in the xml file
  *            report.pageFooter(Templates.footerComponent);
@@ -883,7 +883,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart    a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param categoryChart a {@link net.sf.dynamicreports.report.builder.chart.AbstractCategoryChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void categoryChart(AdhocChart adhocChart, AbstractCategoryChartBuilder<?, ?> categoryChart) {
         baseChart(adhocChart, categoryChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -923,7 +923,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart      a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param timeSeriesChart a {@link net.sf.dynamicreports.report.builder.chart.AbstractTimeSeriesChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void timeSeriesChart(AdhocChart adhocChart, AbstractTimeSeriesChartBuilder<?, ?> timeSeriesChart) {
         baseChart(adhocChart, timeSeriesChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -993,7 +993,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param pieChart   a {@link net.sf.dynamicreports.report.builder.chart.AbstractPieChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void pieChart(AdhocChart adhocChart, AbstractPieChartBuilder<?, ?> pieChart) {
         baseChart(adhocChart, pieChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -1020,7 +1020,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param xyChart    a {@link net.sf.dynamicreports.report.builder.chart.AbstractXyChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void xyChart(AdhocChart adhocChart, AbstractXyChartBuilder<?, ?> xyChart) {
         baseChart(adhocChart, xyChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -1051,7 +1051,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart  a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param spiderChart a {@link net.sf.dynamicreports.report.builder.chart.SpiderChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void spiderChart(AdhocChart adhocChart, SpiderChartBuilder spiderChart) {
         chart(adhocChart, spiderChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -1074,7 +1074,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChart  a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChart} object.
      * @param bubbleChart a {@link net.sf.dynamicreports.report.builder.chart.BubbleChartBuilder} object.
      */
-    @SuppressWarnings( {"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void bubbleChart(AdhocChart adhocChart, BubbleChartBuilder bubbleChart) {
         baseChart(adhocChart, bubbleChart);
         ColumnBuilder valueColumn = columns.get(adhocChart.getXValue());
@@ -1439,7 +1439,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChartSerie a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChartSerie} object.
      * @return a {@link net.sf.dynamicreports.report.builder.chart.CategoryChartSerieBuilder} object.
      */
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected CategoryChartSerieBuilder categoryChartSerie(AdhocChartSerie adhocChartSerie) {
         CategoryChartSerieBuilder categoryChartSerie;
         ColumnBuilder valueColumn = columns.get(adhocChartSerie.getYValue());
@@ -1467,7 +1467,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChartSerie a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChartSerie} object.
      * @return a {@link net.sf.dynamicreports.report.builder.chart.GroupedCategoryChartSerieBuilder} object.
      */
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected GroupedCategoryChartSerieBuilder groupedCategoryChartSerie(AdhocChartSerie adhocChartSerie) {
         GroupedCategoryChartSerieBuilder groupedCategoryChartSerie;
         ColumnBuilder valueColumn = columns.get(adhocChartSerie.getYValue());
@@ -1505,7 +1505,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChartSerie a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChartSerie} object.
      * @return a {@link net.sf.dynamicreports.report.builder.chart.XyChartSerieBuilder} object.
      */
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected XyChartSerieBuilder xyChartSerie(AdhocChartSerie adhocChartSerie) {
         XyChartSerieBuilder xyChartSerie;
         ColumnBuilder valueColumn = columns.get(adhocChartSerie.getYValue());
@@ -1542,7 +1542,7 @@ public class DefaultAdhocReportCustomizer implements AdhocReportCustomizer {
      * @param adhocChartSerie a {@link net.sf.dynamicreports.adhoc.configuration.AdhocChartSerie} object.
      * @return a {@link net.sf.dynamicreports.report.builder.chart.XyzChartSerieBuilder} object.
      */
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected XyzChartSerieBuilder xyzChartSerie(AdhocChartSerie adhocChartSerie) {
         XyzChartSerieBuilder xyzChartSerie = Charts.xyzSerie();
         chartSerie(adhocChartSerie, xyzChartSerie);

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/AdhocToXmlTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/AdhocToXmlTransform.java
@@ -110,7 +110,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class AdhocToXmlTransform {
+public class AdhocToXmlTransform implements IAdhocToXmlTransform {
 
     private static final Logger log = getLogger(AdhocToXmlTransform.class);
 
@@ -120,6 +120,7 @@ public class AdhocToXmlTransform {
      * @param adhocConfiguration a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
      * @return a {@link net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration} object.
      */
+    @Override
     public XmlAdhocConfiguration transform(AdhocConfiguration adhocConfiguration) {
         log.debug("Transforming object : {} to XmlAdhocConfiguration", adhocConfiguration);
         XmlAdhocConfiguration xmlAdhocConfiguration = new XmlAdhocConfiguration();

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/AdhocToXmlTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/AdhocToXmlTransform.java
@@ -93,7 +93,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Used by the library to convert an object into one that can be used by the JAXB api to marshall an object into an xml file. This is not used in general but is specific to configurations used in the
  * adhoc module. An instance of this class may be applied as follows:
  * <pre>
- *     {@link
+ *     {@code
  *     XmlAdhocConfiguration xmlAdhocConfiguration = adhocToXmlTransform.transform(adhocConfiguration);
  *
  *     Marshaller marshaller = JAXBContext.newInstance(XmlAdhocConfiguration.class).createMarshaller();

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IAdhocToXmlTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IAdhocToXmlTransform.java
@@ -1,6 +1,7 @@
 package net.sf.dynamicreports.adhoc.transformation;
 
 import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationMarshallerException;
 import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
 
 public interface IAdhocToXmlTransform {
@@ -10,5 +11,5 @@ public interface IAdhocToXmlTransform {
      * @param adhocConfiguration a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
      * @return a {@link net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration} object.
      */
-    XmlAdhocConfiguration transform(AdhocConfiguration adhocConfiguration);
+    XmlAdhocConfiguration transform(AdhocConfiguration adhocConfiguration) throws ConfigurationMarshallerException;
 }

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IAdhocToXmlTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IAdhocToXmlTransform.java
@@ -1,0 +1,14 @@
+package net.sf.dynamicreports.adhoc.transformation;
+
+import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
+
+public interface IAdhocToXmlTransform {
+    /**
+     * <p>transform.</p>
+     *
+     * @param adhocConfiguration a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
+     * @return a {@link net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration} object.
+     */
+    XmlAdhocConfiguration transform(AdhocConfiguration adhocConfiguration);
+}

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IXmlToAdhocTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/IXmlToAdhocTransform.java
@@ -1,0 +1,15 @@
+package net.sf.dynamicreports.adhoc.transformation;
+
+import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationUnMarshallerException;
+import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
+
+public interface IXmlToAdhocTransform {
+    /**
+     * <p>transform.</p>
+     *
+     * @param xmlAdhocConfiguration a {@link net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration} object.
+     * @return a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
+     */
+    AdhocConfiguration transform(XmlAdhocConfiguration xmlAdhocConfiguration) throws ConfigurationUnMarshallerException;
+}

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/XmlToAdhocTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/XmlToAdhocTransform.java
@@ -152,7 +152,7 @@ public class XmlToAdhocTransform {
             return value;
         }
         if (valueClass.equals(Boolean.class.getName())) {
-            return new Boolean(value);
+            return Boolean.valueOf(value);
         }
         if (valueClass.equals(Integer.class.getName())) {
             return new Integer(value);

--- a/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/XmlToAdhocTransform.java
+++ b/dynamicreports-adhoc/src/main/java/net/sf/dynamicreports/adhoc/transformation/XmlToAdhocTransform.java
@@ -105,7 +105,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class XmlToAdhocTransform {
+public class XmlToAdhocTransform implements IXmlToAdhocTransform {
 
     private static final Logger log = getLogger(XmlToAdhocTransform.class);
 
@@ -115,6 +115,7 @@ public class XmlToAdhocTransform {
      * @param xmlAdhocConfiguration a {@link net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration} object.
      * @return a {@link net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration} object.
      */
+    @Override
     public AdhocConfiguration transform(XmlAdhocConfiguration xmlAdhocConfiguration) {
         log.debug("Transforming XmlAdhocConfiguration : {} to adhocConfiguration", xmlAdhocConfiguration);
         AdhocConfiguration adhocConfiguration = new AdhocConfiguration();

--- a/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/AdhocToXmlTransformDecorator.java
+++ b/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/AdhocToXmlTransformDecorator.java
@@ -1,0 +1,29 @@
+package net.sf.dynamicreports.adhoc;
+
+import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationMarshallerException;
+import net.sf.dynamicreports.adhoc.transformation.IAdhocToXmlTransform;
+import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
+
+public class AdhocToXmlTransformDecorator implements IAdhocToXmlTransform {
+
+    private IAdhocToXmlTransform adhocToXmlTransform;
+
+    public AdhocToXmlTransformDecorator(IAdhocToXmlTransform adhocToXmlTransform) {
+        this.adhocToXmlTransform = adhocToXmlTransform;
+    }
+
+    /**
+     * <p>transform.</p>
+     *
+     * @param adhocConfiguration a {@link AdhocConfiguration} object.
+     * @return a {@link XmlAdhocConfiguration} object.
+     */
+    @Override
+    public XmlAdhocConfiguration transform(AdhocConfiguration adhocConfiguration) throws ConfigurationMarshallerException {
+        if (adhocConfiguration == null || adhocConfiguration.getFilter() == null || adhocConfiguration.getReport() == null){
+            throw new ConfigurationMarshallerException("The ad-hoc-configuration has not been configured");
+        }
+        return adhocToXmlTransform.transform(adhocConfiguration);
+    }
+}

--- a/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/XmlToAdhocTransformDecorator.java
+++ b/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/XmlToAdhocTransformDecorator.java
@@ -1,0 +1,32 @@
+package net.sf.dynamicreports.adhoc;
+
+import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationUnMarshallerException;
+import net.sf.dynamicreports.adhoc.transformation.IXmlToAdhocTransform;
+import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
+import net.sf.dynamicreports.adhoc.xmlconfiguration.XmlAdhocConfiguration;
+
+public class XmlToAdhocTransformDecorator implements IXmlToAdhocTransform {
+
+    private final XmlToAdhocTransform xmlToAdhocTransform;
+
+    public XmlToAdhocTransformDecorator(XmlToAdhocTransform xmlToAdhocTransform) {
+        this.xmlToAdhocTransform = xmlToAdhocTransform;
+    }
+
+    /**
+     * <p>transform.</p>
+     *
+     * @param xmlAdhocConfiguration a {@link XmlAdhocConfiguration} object.
+     * @return a {@link AdhocConfiguration} object.
+     */
+    @Override
+    public AdhocConfiguration transform(XmlAdhocConfiguration xmlAdhocConfiguration) throws ConfigurationUnMarshallerException {
+
+        if (xmlAdhocConfiguration == null || xmlAdhocConfiguration.getFilter() == null || xmlAdhocConfiguration.getReport() == null) {
+            throw new ConfigurationUnMarshallerException("The ad-hoc-configuration has not been configured");
+        }
+
+        return xmlToAdhocTransform.transform(xmlAdhocConfiguration);
+    }
+}

--- a/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocExceptionsTests.java
+++ b/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocExceptionsTests.java
@@ -2,9 +2,11 @@ package net.sf.dynamicreports.adhoc.test;
 
 import net.sf.dynamicreports.adhoc.AdhocManager;
 import net.sf.dynamicreports.adhoc.AdhocToXmlTransformDecorator;
+import net.sf.dynamicreports.adhoc.XmlToAdhocTransformDecorator;
 import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
 import net.sf.dynamicreports.adhoc.configuration.AdhocReport;
 import net.sf.dynamicreports.adhoc.exception.ConfigurationMarshallerException;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationUnMarshallerException;
 import net.sf.dynamicreports.adhoc.transformation.AdhocToXmlTransform;
 import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
 import net.sf.dynamicreports.report.exception.DRException;
@@ -14,12 +16,15 @@ import java.io.ByteArrayOutputStream;
 
 public class AdhocExceptionsTests {
 
-    private AdhocManager adhocManager =
+    private AdhocManager adhocMan =
             AdhocManager.getInstance(
                     new AdhocToXmlTransformDecorator(new AdhocToXmlTransform()),
-                    new XmlToAdhocTransform());
+                    new XmlToAdhocTransformDecorator(new XmlToAdhocTransform()));
+    // TODO IXmlToAdhocTransform interface
+    // TODO XmlToAdhocTransformDecorator
+    // TODO call ConfigurationMarshallerException from XmlToAdhocTransformDecorator for null pointers
 
-    @Test
+    @Test(expected = ConfigurationMarshallerException.class)
     public void libraryCannotTransformNull() throws DRException {
 
         AdhocConfiguration configuration = new AdhocConfiguration();
@@ -28,6 +33,12 @@ public class AdhocExceptionsTests {
         configuration.setReport(adhocReport);
         configuration.setFilter(null); // The catch is that java makes this possible, we don't want this possible
 
-        adhocManager.saveConfiguration(configuration, new ByteArrayOutputStream());
+        adhocMan.saveConfiguration(configuration, new ByteArrayOutputStream());
+    }
+
+    @Test(expected = ConfigurationUnMarshallerException.class)
+    public void libraryCannotUnMarshallNull() throws DRException {
+
+        adhocMan.loadConfiguration(null);
     }
 }

--- a/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocExceptionsTests.java
+++ b/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocExceptionsTests.java
@@ -1,0 +1,33 @@
+package net.sf.dynamicreports.adhoc.test;
+
+import net.sf.dynamicreports.adhoc.AdhocManager;
+import net.sf.dynamicreports.adhoc.AdhocToXmlTransformDecorator;
+import net.sf.dynamicreports.adhoc.configuration.AdhocConfiguration;
+import net.sf.dynamicreports.adhoc.configuration.AdhocReport;
+import net.sf.dynamicreports.adhoc.exception.ConfigurationMarshallerException;
+import net.sf.dynamicreports.adhoc.transformation.AdhocToXmlTransform;
+import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
+import net.sf.dynamicreports.report.exception.DRException;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+public class AdhocExceptionsTests {
+
+    private AdhocManager adhocManager =
+            AdhocManager.getInstance(
+                    new AdhocToXmlTransformDecorator(new AdhocToXmlTransform()),
+                    new XmlToAdhocTransform());
+
+    @Test
+    public void libraryCannotTransformNull() throws DRException {
+
+        AdhocConfiguration configuration = new AdhocConfiguration();
+        AdhocReport adhocReport = new AdhocReport();
+        adhocReport.setProperty("Test_Property", "Test_Property_01");
+        configuration.setReport(adhocReport);
+        configuration.setFilter(null); // The catch is that java makes this possible, we don't want this possible
+
+        adhocManager.saveConfiguration(configuration, new ByteArrayOutputStream());
+    }
+}

--- a/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocTests.java
+++ b/dynamicreports-adhoc/src/test/java/net/sf/dynamicreports/adhoc/test/AdhocTests.java
@@ -25,6 +25,10 @@ import net.sf.dynamicreports.adhoc.AdhocManager;
 import net.sf.dynamicreports.adhoc.transformation.AdhocToXmlTransform;
 import net.sf.dynamicreports.adhoc.transformation.XmlToAdhocTransform;
 
+
+/**
+ * This is an abstract class for all the tests in this module
+ */
 public class AdhocTests {
 
     protected AdhocManager adhocManager = AdhocManager.getInstance(new AdhocToXmlTransform(), new XmlToAdhocTransform());

--- a/dynamicreports-core/pom.xml
+++ b/dynamicreports-core/pom.xml
@@ -261,6 +261,7 @@
                         </executions>
                         <configuration>
                             <excludes>module-info.java</excludes>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                             <headerLocation>../src/etc/checkstyle.xml</headerLocation>
                             <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
                             <configLocation>../src/etc/checkstyle.xml</configLocation>
@@ -379,6 +380,8 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <doclint>none</doclint>
+                            <additionalparam>${javadoc.opts}</additionalparam>
                             <nosince>false</nosince>
                             <failOnError>false</failOnError>
                             <doclint>none</doclint>
@@ -419,5 +422,16 @@
                 </dependency>
             </dependencies>
         </profile>
+
+        <profile>
+            <id>java8-doclint-disabled</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/dynamicreports-core/pom.xml
+++ b/dynamicreports-core/pom.xml
@@ -156,9 +156,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <!--//TODO this could be causing serious animal sniffer errors-->
-                    <!--<source>9</source>
-                    <target>9</target>-->
                     <source>${sourceVersion}</source>
                     <target>${targetVersion}</target>
                     <encoding>${encoding}</encoding>
@@ -168,6 +165,44 @@
             <plugin>
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <!--Could run with mvn clean verify-->
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>run-checkstyle</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>module-info.java</excludes>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    <headerLocation>../src/etc/checkstyle.xml</headerLocation>
+                    <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
+                    <configLocation>../src/etc/checkstyle.xml</configLocation>
+                    <consoleOutput>${checkstyle.config.consoleOutput}</consoleOutput>
+                    <failsOnError>${checkstyle.config.failsOnError}</failsOnError>
+                    <includeResources>${checkstyle.config.includeResources}</includeResources>
+                    <includeTestResources>${checkstyle.config.includeTestResources}</includeTestResources>
+                    <includeTestSourceDirectory>${checkstyle.config.includeTestSourceDirectory}</includeTestSourceDirectory>
+                    <linkXRef>${linkXRef}</linkXRef>
+                </configuration>
             </plugin>
             <!--//TODO fix "commandline was too long error"-->
             <!--<plugin>

--- a/dynamicreports-core/pom.xml
+++ b/dynamicreports-core/pom.xml
@@ -204,6 +204,40 @@
                     <linkXRef>${linkXRef}</linkXRef>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <!--// TODO Use javadoc from JAVA 10 to create searcheable javadocs-->
+                    <!--<javadocExecutable>${env.JAVA_10_HOME}\bin\javadoc.exe</javadocExecutable>-->
+                    <sourceFileExcludes>
+                        <sourceFileExclude>${project.basedir}/dynamicreports-core/target</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
             <!--//TODO fix "commandline was too long error"-->
             <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dynamicreports-core/pom.xml
+++ b/dynamicreports-core/pom.xml
@@ -385,6 +385,9 @@
                             <defaultVersion>${project.version}</defaultVersion>
                             <defaultSince>${project.version}</defaultSince>
                             <javadocExecutable>${env.JAVA_10_HOME}\bin\javadoc.exe</javadocExecutable>
+                            <sourceFileExcludes>
+                                <sourceFileExclude>${project.basedir}/dynamicreports-core/target</sourceFileExclude>
+                            </sourceFileExcludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignBand.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignBand.java
@@ -53,17 +53,13 @@ public class DRDesignBand implements DRIDesignBand {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getSplitType() {
         return splitType;
@@ -78,9 +74,7 @@ public class DRDesignBand implements DRIDesignBand {
         this.splitType = splitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignList getList() {
         return list;
@@ -114,9 +108,7 @@ public class DRDesignBand implements DRIDesignBand {
         list.addComponent(index, component);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignComponent getBandComponent() {
         return bandComponent;
@@ -131,9 +123,7 @@ public class DRDesignBand implements DRIDesignBand {
         this.bandComponent = component;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getHeight() {
         return height;
@@ -148,9 +138,7 @@ public class DRDesignBand implements DRIDesignBand {
         this.height = height;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPrintWhenExpression() {
         return printWhenExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignDataset.java
@@ -62,9 +62,7 @@ public class DRDesignDataset implements DRIDesignDataset {
         this.name = ReportUtils.generateUniqueName("dataset");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -79,65 +77,49 @@ public class DRDesignDataset implements DRIDesignDataset {
         return datasetExpressionTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignField> getFields() {
         return datasetExpressionTransform.getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignVariable> getVariables() {
         return datasetExpressionTransform.getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSystemExpression> getSystemExpressions() {
         return datasetExpressionTransform.getSystemExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignJasperExpression> getJasperExpressions() {
         return datasetExpressionTransform.getJasperExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSimpleExpression> getSimpleExpressions() {
         return datasetExpressionTransform.getSimpleExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignComplexExpression> getComplexExpressions() {
         return datasetExpressionTransform.getComplexExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSort> getSorts() {
         return datasetExpressionTransform.getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignQuery getQuery() {
         return query;
@@ -152,9 +134,7 @@ public class DRDesignDataset implements DRIDesignDataset {
         this.query = query;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getConnectionExpression() {
         return connectionExpression;
@@ -169,9 +149,7 @@ public class DRDesignDataset implements DRIDesignDataset {
         this.connectionExpression = connectionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataSourceExpression() {
         return dataSourceExpression;
@@ -186,9 +164,7 @@ public class DRDesignDataset implements DRIDesignDataset {
         this.dataSourceExpression = dataSourceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getFilterExpression() {
         return filterExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignField.java
@@ -45,9 +45,7 @@ public class DRDesignField implements DRIDesignField {
         this.external = false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -62,9 +60,7 @@ public class DRDesignField implements DRIDesignField {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return valueClass;
@@ -79,9 +75,7 @@ public class DRDesignField implements DRIDesignField {
         this.valueClass = valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isExternal() {
         return external;
@@ -96,9 +90,7 @@ public class DRDesignField implements DRIDesignField {
         this.external = external;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getDescription() {
         return description;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignGroup.java
@@ -66,17 +66,13 @@ public class DRDesignGroup implements DRIDesignGroup {
         footerBands = new ArrayList<DRDesignBand>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getGroupExpression() {
         return groupExpression;
@@ -91,9 +87,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.groupExpression = groupExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignBand> getHeaderBands() {
         return headerBands;
@@ -117,9 +111,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.headerBands.add(headerBand);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignBand> getFooterBands() {
         return footerBands;
@@ -153,9 +145,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.footerBands.add(index, footerBand);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isStartInNewPage() {
         return startInNewPage;
@@ -170,9 +160,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.startInNewPage = startInNewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isStartInNewColumn() {
         return startInNewColumn;
@@ -187,9 +175,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.startInNewColumn = startInNewColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isReprintHeaderOnEachPage() {
         return reprintHeaderOnEachPage;
@@ -204,9 +190,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.reprintHeaderOnEachPage = reprintHeaderOnEachPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isResetPageNumber() {
         return resetPageNumber;
@@ -221,9 +205,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.resetPageNumber = resetPageNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinHeightToStartNewPage() {
         return minHeightToStartNewPage;
@@ -238,9 +220,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.minHeightToStartNewPage = minHeightToStartNewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupFooterPosition getFooterPosition() {
         return footerPosition;
@@ -255,9 +235,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.footerPosition = footerPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isKeepTogether() {
         return keepTogether;
@@ -272,9 +250,7 @@ public class DRDesignGroup implements DRIDesignGroup {
         this.keepTogether = keepTogether;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isHeaderWithSubtotal() {
         return headerWithSubtotal;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignHyperLink.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignHyperLink.java
@@ -41,9 +41,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
     private String hyperLinkType;
     private String hyperLinkTarget;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getAnchorExpression() {
         return anchorExpression;
@@ -58,9 +56,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
         this.anchorExpression = anchorExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPageExpression() {
         return pageExpression;
@@ -75,9 +71,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
         this.pageExpression = pageExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getReferenceExpression() {
         return referenceExpression;
@@ -92,9 +86,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
         this.referenceExpression = referenceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getTooltipExpression() {
         return tooltipExpression;
@@ -109,9 +101,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
         this.tooltipExpression = tooltipExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getType() {
         return hyperLinkType;
@@ -126,9 +116,7 @@ public class DRDesignHyperLink implements DRIDesignHyperLink {
         this.hyperLinkType = hyperLinkType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTarget() {
         return hyperLinkTarget;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignMargin.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignMargin.java
@@ -38,9 +38,7 @@ public class DRDesignMargin implements DRIDesignMargin {
     private int bottom;
     private int right;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getTop() {
         return top;
@@ -55,9 +53,7 @@ public class DRDesignMargin implements DRIDesignMargin {
         this.top = top;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getLeft() {
         return left;
@@ -72,9 +68,7 @@ public class DRDesignMargin implements DRIDesignMargin {
         this.left = left;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getBottom() {
         return bottom;
@@ -89,9 +83,7 @@ public class DRDesignMargin implements DRIDesignMargin {
         this.bottom = bottom;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getRight() {
         return right;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignPage.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignPage.java
@@ -42,9 +42,7 @@ public class DRDesignPage implements DRIDesignPage {
     private int columnSpace;
     private int columnWidth;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getWidth() {
         return width;
@@ -59,9 +57,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.width = width;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getHeight() {
         return height;
@@ -76,9 +72,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.height = height;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageOrientation getOrientation() {
         return orientation;
@@ -93,9 +87,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignMargin getMargin() {
         return margin;
@@ -110,9 +102,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.margin = margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnsPerPage() {
         return columnsPerPage;
@@ -127,9 +117,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.columnsPerPage = columnsPerPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnSpace() {
         return columnSpace;
@@ -144,9 +132,7 @@ public class DRDesignPage implements DRIDesignPage {
         this.columnSpace = columnSpace;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnWidth() {
         return columnWidth;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignParameter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignParameter.java
@@ -38,9 +38,7 @@ public class DRDesignParameter implements DRIDesignParameter {
     private Object value;
     private boolean external;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -55,9 +53,7 @@ public class DRDesignParameter implements DRIDesignParameter {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return valueClass;
@@ -72,9 +68,7 @@ public class DRDesignParameter implements DRIDesignParameter {
         this.valueClass = valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object getValue() {
         return value;
@@ -89,9 +83,7 @@ public class DRDesignParameter implements DRIDesignParameter {
         this.value = value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isExternal() {
         return external;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignQuery.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignQuery.java
@@ -36,9 +36,7 @@ public class DRDesignQuery implements DRIDesignQuery {
     private String text;
     private String language;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getText() {
         return text;
@@ -53,9 +51,7 @@ public class DRDesignQuery implements DRIDesignQuery {
         this.text = text;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLanguage() {
         return language;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignReport.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignReport.java
@@ -162,57 +162,43 @@ public class DRDesignReport implements DesignTransformAccessor, DRIDesignReport 
         styleTransform.transformTemplateStyles();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReport getReport() {
         return report;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageWidth() {
         return pageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ReportTransform getReportTransform() {
         return reportTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TemplateTransform getTemplateTransform() {
         return templateTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageTransform getPageTransform() {
         return pageTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void transformToMainDataset() {
         transformToDataset(null);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void transformToDataset(DRIDataset dataset) {
         if (dataset != null) {
@@ -222,457 +208,343 @@ public class DRDesignReport implements DesignTransformAccessor, DRIDesignReport 
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public AbstractExpressionTransform getExpressionTransform() {
         return expressionTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BandTransform getBandTransform() {
         return bandTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentTransform getComponentTransform() {
         return componentTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupTransform getGroupTransform() {
         return groupTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ColumnTransform getColumnTransform() {
         return columnTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ColumnGridTransform getColumnGridTransform() {
         return columnGridTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public StyleTransform getStyleTransform() {
         return styleTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ChartTransform getChartTransform() {
         return chartTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeTransform getBarcodeTransform() {
         return barcodeTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabTransform getCrosstabTransform() {
         return crosstabTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DatasetTransform getDatasetTransform() {
         return datasetTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TableOfContentsTransform getTableOfContentsTransform() {
         return tableOfContentsTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignTemplateDesign getTemplateDesign() {
         return reportTransform.getTemplateDesign();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getReportName() {
         return templateTransform.getReportName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Locale getLocale() {
         return templateTransform.getLocale();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ResourceBundle getResourceBundle() {
         return report.getResourceBundle();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getResourceBundleName() {
         return templateTransform.getResourceBundleName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isIgnorePagination() {
         return templateTransform.isIgnorePagination();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Properties getProperties() {
         return report.getProperties();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignQuery getQuery() {
         return reportTransform.getQuery();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPage getPage() {
         return pageTransform.getPage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenNoDataType getWhenNoDataType() {
         return templateTransform.getWhenNoDataType(getDetailBands().isEmpty(), getNoDataBand());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenResourceMissingType getWhenResourceMissingType() {
         return templateTransform.getWhenResourceMissingType();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isTitleOnANewPage() {
         return templateTransform.isTitleOnANewPage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isSummaryOnANewPage() {
         return templateTransform.isSummaryOnANewPage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isSummaryWithPageHeaderAndFooter() {
         return templateTransform.isSummaryWithPageHeaderAndFooter();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isFloatColumnFooter() {
         return templateTransform.isFloatColumnFooter();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Orientation getPrintOrder() {
         return templateTransform.getPrintOrder();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getColumnDirection() {
         return templateTransform.getColumnDirection();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLanguage() {
         return templateTransform.getLanguage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isTableOfContents() {
         return templateTransform.isTableOfContents(tocHeadings);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, JasperTocHeading> getTableOfContentsHeadings() {
         return tocHeadings;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRITableOfContentsCustomizer getTableOfContentsCustomizer() {
         return templateTransform.getTableOfContentsCustomizer();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getFilterExpression() {
         return reportTransform.getFilterExpression();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignParameter> getParameters() {
         return reportTransform.getParameters();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, Object> getParameterValues() {
         return report.getParameterValues();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIScriptlet> getScriptlets() {
         return report.getScriptlets();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignField> getFields() {
         return mainDatasetExpressionTransform.getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSystemExpression> getSystemExpressions() {
         return mainDatasetExpressionTransform.getSystemExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignJasperExpression> getJasperExpressions() {
         return mainDatasetExpressionTransform.getJasperExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSimpleExpression> getSimpleExpressions() {
         return mainDatasetExpressionTransform.getSimpleExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignStyle> getStyles() {
         return styleTransform.getStyles();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRDesignGroup> getGroups() {
         return groupTransform.getGroups();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignVariable> getVariables() {
         return mainDatasetExpressionTransform.getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignComplexExpression> getComplexExpressions() {
         return mainDatasetExpressionTransform.getComplexExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignSort> getSorts() {
         return mainDatasetExpressionTransform.getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Collection<DRIDesignDataset> getDatasets() {
         return datasetTransform.getDatasets();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getTitleBand() {
         return bandTransform.getTitleBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getPageHeaderBand() {
         return bandTransform.getPageHeaderBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getPageFooterBand() {
         return bandTransform.getPageFooterBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getColumnHeaderBand() {
         return bandTransform.getColumnHeaderBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getColumnFooterBand() {
         return bandTransform.getColumnFooterBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignBand> getDetailBands() {
         return bandTransform.getDetailBands();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getLastPageFooterBand() {
         return bandTransform.getLastPageFooterBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getSummaryBand() {
         return bandTransform.getSummaryBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getNoDataBand() {
         return bandTransform.getNoDataBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBand getBackgroundBand() {
         return bandTransform.getBackgroundBand();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignSort.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignSort.java
@@ -38,9 +38,7 @@ public class DRDesignSort implements DRIDesignSort {
     private DRIDesignExpression expression;
     private OrderType orderType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getExpression() {
         return expression;
@@ -55,9 +53,7 @@ public class DRDesignSort implements DRIDesignSort {
         this.expression = expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OrderType getOrderType() {
         return orderType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignTableOfContentsHeading.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignTableOfContentsHeading.java
@@ -36,9 +36,7 @@ public class DRDesignTableOfContentsHeading implements DRIDesignTableOfContentsH
 
     private DRDesignTextField referenceField;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignTextField getReferenceField() {
         return referenceField;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignTemplateDesign.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignTemplateDesign.java
@@ -46,81 +46,61 @@ public class DRDesignTemplateDesign implements DRIDesignTemplateDesign {
         this.templateDesign = templateDesign;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getTitleComponentsCount() {
         return templateDesign.getTitleComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageHeaderComponentsCount() {
         return templateDesign.getPageHeaderComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageFooterComponentsCount() {
         return templateDesign.getPageFooterComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnHeaderComponentsCount() {
         return templateDesign.getColumnHeaderComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnFooterComponentsCount() {
         return templateDesign.getColumnFooterComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getLastPageFooterComponentsCount() {
         return templateDesign.getLastPageFooterComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getSummaryComponentsCount() {
         return templateDesign.getSummaryComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getNoDataComponentsCount() {
         return templateDesign.getNoDataComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getBackgroundComponentsCount() {
         return templateDesign.getBackgroundComponentsCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object getDesign() throws DRException {
         return templateDesign.getDesign();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignVariable.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/DRDesignVariable.java
@@ -60,17 +60,13 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;
@@ -85,9 +81,7 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getInitialValueExpression() {
         return initialValueExpression;
@@ -102,9 +96,7 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.initialValueExpression = initialValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Calculation getCalculation() {
         return calculation;
@@ -119,9 +111,7 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.calculation = calculation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ResetType getResetType() {
         return resetType;
@@ -136,9 +126,7 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.resetType = resetType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getResetGroup() {
         return resetGroup;
@@ -153,9 +141,7 @@ public class DRDesignVariable implements DRIDesignVariable {
         this.resetGroup = resetGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return ReportUtils.getVariableValueClass(calculation, valueExpression.getValueClass());

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarbecue.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarbecue.java
@@ -57,9 +57,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         super("barbecue");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarbecueType getType() {
         return type;
@@ -74,9 +72,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getCodeExpression() {
         return codeExpression;
@@ -91,9 +87,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.codeExpression = codeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getApplicationIdentifierExpression() {
         return applicationIdentifierExpression;
@@ -108,9 +102,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.applicationIdentifierExpression = applicationIdentifierExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDrawText() {
         return drawText;
@@ -125,9 +117,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.drawText = drawText;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getChecksumRequired() {
         return checksumRequired;
@@ -142,9 +132,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.checksumRequired = checksumRequired;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarWidth() {
         return barWidth;
@@ -159,9 +147,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.barWidth = barWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarHeight() {
         return barHeight;
@@ -176,9 +162,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.barHeight = barHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeOrientation getOrientation() {
         return orientation;
@@ -193,9 +177,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -210,9 +192,7 @@ public class DRDesignBarbecue extends DRDesignComponent implements DRIDesignBarb
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignGroup getEvaluationGroup() {
         return evaluationGroup;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarcode.java
@@ -50,9 +50,7 @@ public abstract class DRDesignBarcode extends DRDesignComponent implements DRIDe
         super(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getCodeExpression() {
         return codeExpression;
@@ -67,9 +65,7 @@ public abstract class DRDesignBarcode extends DRDesignComponent implements DRIDe
         this.codeExpression = codeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -84,9 +80,7 @@ public abstract class DRDesignBarcode extends DRDesignComponent implements DRIDe
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignGroup getEvaluationGroup() {
         return evaluationGroup;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarcode4j.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignBarcode4j.java
@@ -52,9 +52,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         super(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPatternExpression() {
         return patternExpression;
@@ -69,9 +67,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         this.patternExpression = patternExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getModuleWidth() {
         return moduleWidth;
@@ -86,9 +82,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         this.moduleWidth = moduleWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeOrientation getOrientation() {
         return orientation;
@@ -103,9 +97,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeTextPosition getTextPosition() {
         return textPosition;
@@ -120,9 +112,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         this.textPosition = textPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getQuietZone() {
         return quietZone;
@@ -137,9 +127,7 @@ public abstract class DRDesignBarcode4j extends DRDesignBarcode implements DRIDe
         this.quietZone = quietZone;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getVerticalQuietZone() {
         return verticalQuietZone;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignChecksumBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignChecksumBarcode.java
@@ -45,9 +45,7 @@ public abstract class DRDesignChecksumBarcode extends DRDesignBarcode4j implemen
         super(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeChecksumMode getChecksumMode() {
         return checksumMode;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignCodabarBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignCodabarBarcode.java
@@ -42,9 +42,7 @@ public class DRDesignCodabarBarcode extends DRDesignBarcode4j implements DRIDesi
         super("Codabar");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignCode39Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignCode39Barcode.java
@@ -46,9 +46,7 @@ public class DRDesignCode39Barcode extends DRDesignChecksumBarcode implements DR
         super("Code39");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -63,9 +61,7 @@ public class DRDesignCode39Barcode extends DRDesignChecksumBarcode implements DR
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayStartStop() {
         return displayStartStop;
@@ -80,9 +76,7 @@ public class DRDesignCode39Barcode extends DRDesignChecksumBarcode implements DR
         this.displayStartStop = displayStartStop;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getExtendedCharSetEnabled() {
         return extendedCharSetEnabled;
@@ -97,9 +91,7 @@ public class DRDesignCode39Barcode extends DRDesignChecksumBarcode implements DR
         this.extendedCharSetEnabled = extendedCharSetEnabled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -114,9 +106,7 @@ public class DRDesignCode39Barcode extends DRDesignChecksumBarcode implements DR
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignDataMatrixBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignDataMatrixBarcode.java
@@ -43,9 +43,7 @@ public class DRDesignDataMatrixBarcode extends DRDesignBarcode4j implements DRID
         super("DataMatrix");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeShape getShape() {
         return shape;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignInterleaved2Of5Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignInterleaved2Of5Barcode.java
@@ -43,9 +43,7 @@ public class DRDesignInterleaved2Of5Barcode extends DRDesignChecksumBarcode impl
         super("Interleaved2Of5");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -60,9 +58,7 @@ public class DRDesignInterleaved2Of5Barcode extends DRDesignChecksumBarcode impl
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignPdf417Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignPdf417Barcode.java
@@ -47,9 +47,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         super("PDF417");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinColumns() {
         return minColumns;
@@ -64,9 +62,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         this.minColumns = minColumns;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMaxColumns() {
         return maxColumns;
@@ -81,9 +77,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         this.maxColumns = maxColumns;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinRows() {
         return minRows;
@@ -98,9 +92,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         this.minRows = minRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMaxRows() {
         return maxRows;
@@ -115,9 +107,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         this.maxRows = maxRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWidthToHeightRatio() {
         return widthToHeightRatio;
@@ -132,9 +122,7 @@ public class DRDesignPdf417Barcode extends DRDesignBarcode4j implements DRIDesig
         this.widthToHeightRatio = widthToHeightRatio;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getErrorCorrectionLevel() {
         return errorCorrectionLevel;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignPostnetBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignPostnetBarcode.java
@@ -46,9 +46,7 @@ public class DRDesignPostnetBarcode extends DRDesignChecksumBarcode implements D
         super("POSTNET");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -63,9 +61,7 @@ public class DRDesignPostnetBarcode extends DRDesignChecksumBarcode implements D
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getShortBarHeight() {
         return shortBarHeight;
@@ -80,9 +76,7 @@ public class DRDesignPostnetBarcode extends DRDesignChecksumBarcode implements D
         this.shortBarHeight = shortBarHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeBaselinePosition getBaselinePosition() {
         return baselinePosition;
@@ -97,9 +91,7 @@ public class DRDesignPostnetBarcode extends DRDesignChecksumBarcode implements D
         this.baselinePosition = baselinePosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignQrCode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignQrCode.java
@@ -44,9 +44,7 @@ public class DRDesignQrCode extends DRDesignBarcode implements DRIDesignQrCode {
         super("QRCode");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMargin() {
         return margin;
@@ -61,9 +59,7 @@ public class DRDesignQrCode extends DRDesignBarcode implements DRIDesignQrCode {
         this.margin = margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public QrCodeErrorCorrectionLevel getErrorCorrectionLevel() {
         return errorCorrectionLevel;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignRoyalMailCustomerBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignRoyalMailCustomerBarcode.java
@@ -44,9 +44,7 @@ public class DRDesignRoyalMailCustomerBarcode extends DRDesignChecksumBarcode im
         super("RoyalMailCustomer");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAscenderHeight() {
         return ascenderHeight;
@@ -61,9 +59,7 @@ public class DRDesignRoyalMailCustomerBarcode extends DRDesignChecksumBarcode im
         this.ascenderHeight = ascenderHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -78,9 +74,7 @@ public class DRDesignRoyalMailCustomerBarcode extends DRDesignChecksumBarcode im
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTrackHeight() {
         return trackHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignUspsIntelligentMailBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/barcode/DRDesignUspsIntelligentMailBarcode.java
@@ -44,9 +44,7 @@ public class DRDesignUspsIntelligentMailBarcode extends DRDesignChecksumBarcode 
         super("USPSIntelligentMail");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAscenderHeight() {
         return ascenderHeight;
@@ -61,9 +59,7 @@ public class DRDesignUspsIntelligentMailBarcode extends DRDesignChecksumBarcode 
         this.ascenderHeight = ascenderHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -78,9 +74,7 @@ public class DRDesignUspsIntelligentMailBarcode extends DRDesignChecksumBarcode 
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTrackHeight() {
         return trackHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChart.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChart.java
@@ -62,9 +62,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         customizers = new ArrayList<DRIChartCustomizer>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ChartType getChartType() {
         return chartType;
@@ -79,9 +77,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.chartType = chartType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignChartDataset getDataset() {
         return dataset;
@@ -96,9 +92,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.dataset = dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignPlot getPlot() {
         return plot;
@@ -113,9 +107,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.plot = plot;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIChartCustomizer> getCustomizers() {
         return customizers;
@@ -130,9 +122,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.customizers = customizers;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignChartTitle getTitle() {
         return title;
@@ -147,9 +137,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.title = title;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignChartSubtitle getSubtitle() {
         return subtitle;
@@ -164,9 +152,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.subtitle = subtitle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignChartLegend getLegend() {
         return legend;
@@ -181,9 +167,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.legend = legend;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -198,9 +182,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getEvaluationGroup() {
         return evaluationGroup;
@@ -215,9 +197,7 @@ public class DRDesignChart extends DRDesignHyperlinkComponent implements DRIDesi
         this.evaluationGroup = evaluationGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTheme() {
         return theme;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartLegend.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartLegend.java
@@ -49,9 +49,7 @@ public class DRDesignChartLegend implements DRIDesignChartLegend {
     public DRDesignChartLegend() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getColor() {
         return color;
@@ -66,9 +64,7 @@ public class DRDesignChartLegend implements DRIDesignChartLegend {
         this.color = color;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -83,9 +79,7 @@ public class DRDesignChartLegend implements DRIDesignChartLegend {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLegend() {
         return showLegend;
@@ -100,9 +94,7 @@ public class DRDesignChartLegend implements DRIDesignChartLegend {
         this.showLegend = showLegend;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignFont getFont() {
         return font;
@@ -117,9 +109,7 @@ public class DRDesignChartLegend implements DRIDesignChartLegend {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getPosition() {
         return position;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartSubtitle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartSubtitle.java
@@ -41,9 +41,7 @@ public class DRDesignChartSubtitle implements DRIDesignChartSubtitle {
     private DRDesignFont font;
     private DRIDesignExpression title;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getColor() {
         return color;
@@ -58,9 +56,7 @@ public class DRDesignChartSubtitle implements DRIDesignChartSubtitle {
         this.color = color;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignFont getFont() {
         return font;
@@ -75,9 +71,7 @@ public class DRDesignChartSubtitle implements DRIDesignChartSubtitle {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getTitle() {
         return title;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartTitle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/DRDesignChartTitle.java
@@ -36,9 +36,7 @@ public class DRDesignChartTitle extends DRDesignChartSubtitle implements DRIDesi
 
     private Position position;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getPosition() {
         return position;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignCategoryChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignCategoryChartSerie.java
@@ -37,9 +37,7 @@ public class DRDesignCategoryChartSerie extends DRDesignChartSerie implements DR
     private DRIDesignExpression valueExpression;
     private DRIDesignExpression labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;
@@ -54,9 +52,7 @@ public class DRDesignCategoryChartSerie extends DRDesignChartSerie implements DR
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignCategoryDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignCategoryDataset.java
@@ -35,9 +35,7 @@ public class DRDesignCategoryDataset extends DRDesignSeriesDataset implements DR
 
     private boolean useSeriesAsCategory;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isUseSeriesAsCategory() {
         return useSeriesAsCategory;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignChartDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignChartDataset.java
@@ -40,9 +40,7 @@ public class DRDesignChartDataset implements DRIDesignChartDataset {
     private ResetType resetType;
     private DRDesignGroup resetGroup;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignDataset getSubDataset() {
         return subDataset;
@@ -57,9 +55,7 @@ public class DRDesignChartDataset implements DRIDesignChartDataset {
         this.subDataset = subDataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ResetType getResetType() {
         return resetType;
@@ -74,9 +70,7 @@ public class DRDesignChartDataset implements DRIDesignChartDataset {
         this.resetType = resetType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getResetGroup() {
         return resetGroup;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignChartSerie.java
@@ -38,9 +38,7 @@ public abstract class DRDesignChartSerie implements DRIDesignChartSerie {
     private DRIDesignExpression seriesExpression;
     private DRIDesignHyperLink itemHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getSeriesExpression() {
         return seriesExpression;
@@ -55,9 +53,7 @@ public abstract class DRDesignChartSerie implements DRIDesignChartSerie {
         this.seriesExpression = seriesExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignHyperLink getItemHyperLink() {
         return itemHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignGanttChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignGanttChartSerie.java
@@ -39,9 +39,7 @@ public class DRDesignGanttChartSerie extends DRDesignChartSerie implements DRIDe
     private DRIDesignExpression percentExpression;
     private DRIDesignExpression labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getStartDateExpression() {
         return startDateExpression;
@@ -56,9 +54,7 @@ public class DRDesignGanttChartSerie extends DRDesignChartSerie implements DRIDe
         this.startDateExpression = startDateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getEndDateExpression() {
         return endDateExpression;
@@ -73,9 +69,7 @@ public class DRDesignGanttChartSerie extends DRDesignChartSerie implements DRIDe
         this.endDateExpression = endDateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPercentExpression() {
         return percentExpression;
@@ -90,9 +84,7 @@ public class DRDesignGanttChartSerie extends DRDesignChartSerie implements DRIDe
         this.percentExpression = percentExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignHighLowDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignHighLowDataset.java
@@ -44,9 +44,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
     private DRIDesignExpression volumeExpression;
     private DRIDesignHyperLink itemHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getSeriesExpression() {
         return seriesExpression;
@@ -61,9 +59,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.seriesExpression = seriesExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDateExpression() {
         return dateExpression;
@@ -78,9 +74,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.dateExpression = dateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getHighExpression() {
         return highExpression;
@@ -95,9 +89,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.highExpression = highExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLowExpression() {
         return lowExpression;
@@ -112,9 +104,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.lowExpression = lowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getOpenExpression() {
         return openExpression;
@@ -129,9 +119,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.openExpression = openExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getCloseExpression() {
         return closeExpression;
@@ -146,9 +134,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.closeExpression = closeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getVolumeExpression() {
         return volumeExpression;
@@ -163,9 +149,7 @@ public class DRDesignHighLowDataset extends DRDesignChartDataset implements DRID
         this.volumeExpression = volumeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignHyperLink getItemHyperLink() {
         return itemHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignSeriesDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignSeriesDataset.java
@@ -48,9 +48,7 @@ public class DRDesignSeriesDataset extends DRDesignChartDataset implements DRIDe
         series = new ArrayList<DRIDesignChartSerie>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;
@@ -74,9 +72,7 @@ public class DRDesignSeriesDataset extends DRDesignChartDataset implements DRIDe
         series.add(serie);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignChartSerie> getSeries() {
         return series;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignTimeSeriesDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignTimeSeriesDataset.java
@@ -36,9 +36,7 @@ public class DRDesignTimeSeriesDataset extends DRDesignSeriesDataset implements 
 
     private TimePeriod timePeriodType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TimePeriod getTimePeriodType() {
         return timePeriodType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignValueDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignValueDataset.java
@@ -36,9 +36,7 @@ public class DRDesignValueDataset extends DRDesignChartDataset implements DRIDes
 
     private DRIDesignExpression valueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignXyChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignXyChartSerie.java
@@ -38,9 +38,7 @@ public class DRDesignXyChartSerie extends DRDesignChartSerie implements DRIDesig
     private DRIDesignExpression yValueExpression;
     private DRIDesignExpression labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getXValueExpression() {
         return xValueExpression;
@@ -55,9 +53,7 @@ public class DRDesignXyChartSerie extends DRDesignChartSerie implements DRIDesig
         this.xValueExpression = xValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getYValueExpression() {
         return yValueExpression;
@@ -72,9 +68,7 @@ public class DRDesignXyChartSerie extends DRDesignChartSerie implements DRIDesig
         this.yValueExpression = yValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignXyzChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/dataset/DRDesignXyzChartSerie.java
@@ -38,9 +38,7 @@ public class DRDesignXyzChartSerie extends DRDesignChartSerie implements DRIDesi
     private DRIDesignExpression yValueExpression;
     private DRIDesignExpression zValueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getXValueExpression() {
         return xValueExpression;
@@ -55,9 +53,7 @@ public class DRDesignXyzChartSerie extends DRDesignChartSerie implements DRIDesi
         this.xValueExpression = xValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getYValueExpression() {
         return yValueExpression;
@@ -72,9 +68,7 @@ public class DRDesignXyzChartSerie extends DRDesignChartSerie implements DRIDesi
         this.yValueExpression = yValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getZValueExpression() {
         return zValueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/AbstractDesignBasePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/AbstractDesignBasePlot.java
@@ -40,9 +40,7 @@ public abstract class AbstractDesignBasePlot implements DRIDesignBasePlot {
     private Orientation orientation;
     private List<Color> seriesColors;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Orientation getOrientation() {
         return orientation;
@@ -57,9 +55,7 @@ public abstract class AbstractDesignBasePlot implements DRIDesignBasePlot {
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<Color> getSeriesColors() {
         return seriesColors;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignAxisFormat.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignAxisFormat.java
@@ -49,9 +49,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
     private DRIDesignExpression rangeMinValueExpression;
     private DRIDesignExpression rangeMaxValueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLabelExpression() {
         return labelExpression;
@@ -66,9 +64,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.labelExpression = labelExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignFont getLabelFont() {
         return labelFont;
@@ -83,9 +79,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.labelFont = labelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLabelColor() {
         return labelColor;
@@ -100,9 +94,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.labelColor = labelColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignFont getTickLabelFont() {
         return tickLabelFont;
@@ -117,9 +109,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.tickLabelFont = tickLabelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getTickLabelColor() {
         return tickLabelColor;
@@ -134,9 +124,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.tickLabelColor = tickLabelColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTickLabelMask() {
         return tickLabelMask;
@@ -151,9 +139,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.tickLabelMask = tickLabelMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getVerticalTickLabels() {
         return verticalTickLabels;
@@ -168,9 +154,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.verticalTickLabels = verticalTickLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTickLabelRotation() {
         return tickLabelRotation;
@@ -185,9 +169,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.tickLabelRotation = tickLabelRotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLineColor() {
         return lineColor;
@@ -202,9 +184,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.lineColor = lineColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getRangeMinValueExpression() {
         return rangeMinValueExpression;
@@ -219,9 +199,7 @@ public class DRDesignAxisFormat implements DRIDesignAxisFormat {
         this.rangeMinValueExpression = rangeMinValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getRangeMaxValueExpression() {
         return rangeMaxValueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignAxisPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignAxisPlot.java
@@ -36,9 +36,7 @@ public class DRDesignAxisPlot extends AbstractDesignBasePlot implements DRIDesig
     private DRDesignAxisFormat xAxisFormat;
     private DRDesignAxisFormat yAxisFormat;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignAxisFormat getXAxisFormat() {
         return xAxisFormat;
@@ -53,9 +51,7 @@ public class DRDesignAxisPlot extends AbstractDesignBasePlot implements DRIDesig
         this.xAxisFormat = xAxisFormat;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignAxisFormat getYAxisFormat() {
         return yAxisFormat;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBar3DPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBar3DPlot.java
@@ -37,9 +37,7 @@ public class DRDesignBar3DPlot extends DRDesignAxisPlot implements DRIDesignBar3
     private Double yOffset;
     private Boolean showLabels;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getXOffset() {
         return xOffset;
@@ -54,9 +52,7 @@ public class DRDesignBar3DPlot extends DRDesignAxisPlot implements DRIDesignBar3
         this.xOffset = xOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getYOffset() {
         return yOffset;
@@ -71,9 +67,7 @@ public class DRDesignBar3DPlot extends DRDesignAxisPlot implements DRIDesignBar3
         this.yOffset = yOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLabels() {
         return showLabels;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBarPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBarPlot.java
@@ -37,9 +37,7 @@ public class DRDesignBarPlot extends DRDesignAxisPlot implements DRIDesignBarPlo
     private Boolean showTickLabels;
     private Boolean showLabels;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLabels() {
         return showLabels;
@@ -54,9 +52,7 @@ public class DRDesignBarPlot extends DRDesignAxisPlot implements DRIDesignBarPlo
         this.showLabels = showLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowTickLabels() {
         return showTickLabels;
@@ -71,9 +67,7 @@ public class DRDesignBarPlot extends DRDesignAxisPlot implements DRIDesignBarPlo
         this.showTickLabels = showTickLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowTickMarks() {
         return showTickMarks;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBubblePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignBubblePlot.java
@@ -36,9 +36,7 @@ public class DRDesignBubblePlot extends DRDesignAxisPlot implements DRIDesignBub
 
     private ScaleType scaleType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ScaleType getScaleType() {
         return scaleType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignCandlestickPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignCandlestickPlot.java
@@ -35,9 +35,7 @@ public class DRDesignCandlestickPlot extends DRDesignAxisPlot implements DRIDesi
 
     private Boolean showVolume;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowVolume() {
         return showVolume;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignChartAxis.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignChartAxis.java
@@ -38,9 +38,7 @@ public class DRDesignChartAxis implements DRIDesignChartAxis {
     private AxisPosition position;
     private DRIDesignChart chart;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public AxisPosition getPosition() {
         return position;
@@ -55,9 +53,7 @@ public class DRDesignChartAxis implements DRIDesignChartAxis {
         this.position = position;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignChart getChart() {
         return chart;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignHighLowPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignHighLowPlot.java
@@ -36,9 +36,7 @@ public class DRDesignHighLowPlot extends DRDesignAxisPlot implements DRIDesignHi
     private Boolean showOpenTicks;
     private Boolean showCloseTicks;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowOpenTicks() {
         return showOpenTicks;
@@ -53,9 +51,7 @@ public class DRDesignHighLowPlot extends DRDesignAxisPlot implements DRIDesignHi
         this.showOpenTicks = showOpenTicks;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowCloseTicks() {
         return showCloseTicks;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignLinePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignLinePlot.java
@@ -36,9 +36,7 @@ public class DRDesignLinePlot extends DRDesignAxisPlot implements DRIDesignLineP
     private Boolean showShapes;
     private Boolean showLines;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowShapes() {
         return showShapes;
@@ -53,9 +51,7 @@ public class DRDesignLinePlot extends DRDesignAxisPlot implements DRIDesignLineP
         this.showShapes = showShapes;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLines() {
         return showLines;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMeterInterval.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMeterInterval.java
@@ -42,9 +42,7 @@ public class DRDesignMeterInterval implements DRIDesignMeterInterval {
     private DRIDesignExpression dataRangeLowExpression;
     private DRIDesignExpression dataRangeHighExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLabel() {
         return label;
@@ -59,9 +57,7 @@ public class DRDesignMeterInterval implements DRIDesignMeterInterval {
         this.label = label;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -76,9 +72,7 @@ public class DRDesignMeterInterval implements DRIDesignMeterInterval {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAlpha() {
         return alpha;
@@ -93,9 +87,7 @@ public class DRDesignMeterInterval implements DRIDesignMeterInterval {
         this.alpha = alpha;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -110,9 +102,7 @@ public class DRDesignMeterInterval implements DRIDesignMeterInterval {
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeHighExpression() {
         return dataRangeHighExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMeterPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMeterPlot.java
@@ -63,9 +63,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         intervals = new ArrayList<DRIDesignMeterInterval>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -80,9 +78,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeHighExpression() {
         return dataRangeHighExpression;
@@ -97,9 +93,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.dataRangeHighExpression = dataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getValueColor() {
         return valueColor;
@@ -114,9 +108,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.valueColor = valueColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValueMask() {
         return valueMask;
@@ -131,9 +123,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.valueMask = valueMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignFont getValueFont() {
         return valueFont;
@@ -148,9 +138,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.valueFont = valueFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public MeterShape getShape() {
         return shape;
@@ -165,9 +153,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.shape = shape;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignMeterInterval> getIntervals() {
         return intervals;
@@ -182,9 +168,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.intervals = intervals;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMeterAngle() {
         return meterAngle;
@@ -199,9 +183,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.meterAngle = meterAngle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getUnits() {
         return units;
@@ -216,9 +198,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.units = units;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTickInterval() {
         return tickInterval;
@@ -233,9 +213,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.tickInterval = tickInterval;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getMeterBackgroundColor() {
         return meterBackgroundColor;
@@ -250,9 +228,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.meterBackgroundColor = meterBackgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getNeedleColor() {
         return needleColor;
@@ -267,9 +243,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.needleColor = needleColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getTickColor() {
         return tickColor;
@@ -284,9 +258,7 @@ public class DRDesignMeterPlot extends DRDesignAxisPlot implements DRIDesignMete
         this.tickColor = tickColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignFont getTickLabelFont() {
         return tickLabelFont;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMultiAxisPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignMultiAxisPlot.java
@@ -46,9 +46,7 @@ public class DRDesignMultiAxisPlot extends DRDesignAxisPlot implements DRIDesign
         axes = new ArrayList<DRIDesignChartAxis>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignChartAxis> getAxes() {
         return axes;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignPie3DPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignPie3DPlot.java
@@ -35,9 +35,7 @@ public class DRDesignPie3DPlot extends DRDesignPiePlot implements DRIDesignPie3D
 
     private Double depthFactor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getDepthFactor() {
         return depthFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignPiePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignPiePlot.java
@@ -37,9 +37,7 @@ public class DRDesignPiePlot extends AbstractDesignBasePlot implements DRIDesign
     private String labelFormat;
     private String legendLabelFormat;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCircular() {
         return circular;
@@ -54,9 +52,7 @@ public class DRDesignPiePlot extends AbstractDesignBasePlot implements DRIDesign
         this.circular = circular;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLabelFormat() {
         return labelFormat;
@@ -71,9 +67,7 @@ public class DRDesignPiePlot extends AbstractDesignBasePlot implements DRIDesign
         this.labelFormat = labelFormat;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLegendLabelFormat() {
         return legendLabelFormat;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignSpiderPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignSpiderPlot.java
@@ -52,9 +52,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
     private Double labelGap;
     private Color labelColor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getMaxValueExpression() {
         return maxValueExpression;
@@ -69,9 +67,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.maxValueExpression = maxValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SpiderRotation getRotation() {
         return rotation;
@@ -86,9 +82,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.rotation = rotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TableOrder getTableOrder() {
         return tableOrder;
@@ -103,9 +97,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.tableOrder = tableOrder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWebFilled() {
         return webFilled;
@@ -120,9 +112,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.webFilled = webFilled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getStartAngle() {
         return startAngle;
@@ -137,9 +127,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.startAngle = startAngle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getHeadPercent() {
         return headPercent;
@@ -154,9 +142,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.headPercent = headPercent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getInteriorGap() {
         return interiorGap;
@@ -171,9 +157,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.interiorGap = interiorGap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getAxisLineColor() {
         return axisLineColor;
@@ -188,9 +172,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.axisLineColor = axisLineColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getAxisLineWidth() {
         return axisLineWidth;
@@ -205,9 +187,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.axisLineWidth = axisLineWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignFont getLabelFont() {
         return labelFont;
@@ -222,9 +202,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.labelFont = labelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getLabelGap() {
         return labelGap;
@@ -239,9 +217,7 @@ public class DRDesignSpiderPlot implements DRIDesignSpiderPlot {
         this.labelGap = labelGap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLabelColor() {
         return labelColor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignThermometerPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/chart/plot/DRDesignThermometerPlot.java
@@ -52,9 +52,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
     private DRIDesignExpression highDataRangeLowExpression;
     private DRIDesignExpression highDataRangeHighExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -69,9 +67,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataRangeHighExpression() {
         return dataRangeHighExpression;
@@ -86,9 +82,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.dataRangeHighExpression = dataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getValueColor() {
         return valueColor;
@@ -103,9 +97,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.valueColor = valueColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValueMask() {
         return valueMask;
@@ -120,9 +112,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.valueMask = valueMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignFont getValueFont() {
         return valueFont;
@@ -137,9 +127,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.valueFont = valueFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ValueLocation getValueLocation() {
         return valueLocation;
@@ -154,9 +142,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.valueLocation = valueLocation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getMercuryColor() {
         return mercuryColor;
@@ -171,9 +157,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.mercuryColor = mercuryColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLowDataRangeLowExpression() {
         return lowDataRangeLowExpression;
@@ -188,9 +172,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.lowDataRangeLowExpression = lowDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLowDataRangeHighExpression() {
         return lowDataRangeHighExpression;
@@ -205,9 +187,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.lowDataRangeHighExpression = lowDataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getMediumDataRangeLowExpression() {
         return mediumDataRangeLowExpression;
@@ -222,9 +202,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.mediumDataRangeLowExpression = mediumDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getMediumDataRangeHighExpression() {
         return mediumDataRangeHighExpression;
@@ -239,9 +217,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.mediumDataRangeHighExpression = mediumDataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getHighDataRangeLowExpression() {
         return highDataRangeLowExpression;
@@ -256,9 +232,7 @@ public class DRDesignThermometerPlot extends DRDesignAxisPlot implements DRIDesi
         this.highDataRangeLowExpression = highDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getHighDataRangeHighExpression() {
         return highDataRangeHighExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignBreak.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignBreak.java
@@ -43,9 +43,7 @@ public class DRDesignBreak extends DRDesignComponent implements DRIDesignBreak {
         super("break");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BreakType getType() {
         return breakType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignComponent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignComponent.java
@@ -78,17 +78,13 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         propertyExpressions = new ArrayList<DRIDesignPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getUniqueName() {
         return uniqueName;
@@ -103,9 +99,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.uniqueName = uniqueName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignStyle getStyle() {
         return style;
@@ -120,9 +114,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.style = style;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getX() {
         return x;
@@ -137,9 +129,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.x = x;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getY() {
         return y;
@@ -154,9 +144,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.y = y;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getWidth() {
         return width;
@@ -171,9 +159,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.width = width;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getHeight() {
         return height;
@@ -188,9 +174,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.height = height;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPrintWhenExpression() {
         return printWhenExpression;
@@ -205,9 +189,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.printWhenExpression = printWhenExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isRemoveLineWhenBlank() {
         return isRemoveLineWhenBlank;
@@ -222,9 +204,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.isRemoveLineWhenBlank = isRemoveLineWhenBlank;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignPropertyExpression> getPropertyExpressions() {
         return propertyExpressions;
@@ -239,9 +219,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.propertyExpressions = propertyExpressions;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentPositionType getPositionType() {
         return positionType;
@@ -256,9 +234,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.positionType = positionType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public StretchType getStretchType() {
         return stretchType;
@@ -273,9 +249,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.stretchType = stretchType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isPrintInFirstWholeBand() {
         return printInFirstWholeBand;
@@ -290,9 +264,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.printInFirstWholeBand = printInFirstWholeBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isPrintWhenDetailOverflows() {
         return printWhenDetailOverflows;
@@ -307,9 +279,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.printWhenDetailOverflows = printWhenDetailOverflows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignGroup getPrintWhenGroupChanges() {
         return printWhenGroupChanges;
@@ -324,9 +294,7 @@ public abstract class DRDesignComponent implements DRIDesignComponent {
         this.printWhenGroupChanges = printWhenGroupChanges;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignTableOfContentsHeading getTableOfContentsHeading() {
         return tableOfContentsHeading;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignEllipse.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignEllipse.java
@@ -43,9 +43,7 @@ public class DRDesignEllipse extends DRDesignComponent implements DRIDesignEllip
         super("ellipse");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignGenericElement.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignGenericElement.java
@@ -52,18 +52,14 @@ public class DRDesignGenericElement extends DRDesignComponent implements DRIDesi
         super("genericElement");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
         parameterExpressions = new ArrayList<DRIDesignParameterExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getGenericElementNamespace() {
         return genericElementNamespace;
@@ -78,9 +74,7 @@ public class DRDesignGenericElement extends DRDesignComponent implements DRIDesi
         this.genericElementNamespace = genericElementNamespace;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getGenericElementName() {
         return genericElementName;
@@ -95,9 +89,7 @@ public class DRDesignGenericElement extends DRDesignComponent implements DRIDesi
         this.genericElementName = genericElementName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -112,9 +104,7 @@ public class DRDesignGenericElement extends DRDesignComponent implements DRIDesi
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getEvaluationGroup() {
         return evaluationGroup;
@@ -129,9 +119,7 @@ public class DRDesignGenericElement extends DRDesignComponent implements DRIDesi
         this.evaluationGroup = evaluationGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignParameterExpression> getParameterExpressions() {
         return parameterExpressions;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignHyperlinkComponent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignHyperlinkComponent.java
@@ -48,9 +48,7 @@ public abstract class DRDesignHyperlinkComponent extends DRDesignComponent imple
         super(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getAnchorNameExpression() {
         return anchorNameExpression;
@@ -65,9 +63,7 @@ public abstract class DRDesignHyperlinkComponent extends DRDesignComponent imple
         this.anchorNameExpression = anchorNameExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBookmarkLevel() {
         return bookmarkLevel;
@@ -82,9 +78,7 @@ public abstract class DRDesignHyperlinkComponent extends DRDesignComponent imple
         this.bookmarkLevel = bookmarkLevel;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignHyperLink getHyperLink() {
         return hyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignImage.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignImage.java
@@ -49,9 +49,7 @@ public class DRDesignImage extends DRDesignHyperlinkComponent implements DRIDesi
         super("image");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getImageExpression() {
         return imageExpression;
@@ -66,9 +64,7 @@ public class DRDesignImage extends DRDesignHyperlinkComponent implements DRIDesi
         this.imageExpression = imageExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageScale getImageScale() {
         return imageScale;
@@ -83,9 +79,7 @@ public class DRDesignImage extends DRDesignHyperlinkComponent implements DRIDesi
         this.imageScale = imageScale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUsingCache() {
         return usingCache;
@@ -100,9 +94,7 @@ public class DRDesignImage extends DRDesignHyperlinkComponent implements DRIDesi
         this.usingCache = usingCache;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getLazy() {
         return lazy;
@@ -117,9 +109,7 @@ public class DRDesignImage extends DRDesignHyperlinkComponent implements DRIDesi
         this.lazy = lazy;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalImageAlignment getHorizontalImageAlignment() {
         return horizontalImageAlignment;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignLine.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignLine.java
@@ -45,9 +45,7 @@ public class DRDesignLine extends DRDesignComponent implements DRIDesignLine {
         super("line");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineDirection getDirection() {
         return direction;
@@ -62,9 +60,7 @@ public class DRDesignLine extends DRDesignComponent implements DRIDesignLine {
         this.direction = direction;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignList.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignList.java
@@ -67,9 +67,7 @@ public class DRDesignList extends DRDesignComponent implements DRIDesignList {
         this.calculateComponents = true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
@@ -77,9 +75,7 @@ public class DRDesignList extends DRDesignComponent implements DRIDesignList {
         this.components = new ArrayList<DRDesignComponent>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignComponent> getComponents() {
         return components;
@@ -149,9 +145,7 @@ public class DRDesignList extends DRDesignComponent implements DRIDesignList {
         return components.isEmpty();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ListType getType() {
         return type;
@@ -166,9 +160,7 @@ public class DRDesignList extends DRDesignComponent implements DRIDesignList {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentGroupType getComponentGroupType() {
         return componentGroupType;
@@ -241,9 +233,7 @@ public class DRDesignList extends DRDesignComponent implements DRIDesignList {
         this.removable = removable;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignComponent getBackgroundComponent() {
         return backgroundComponent;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignMap.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignMap.java
@@ -49,9 +49,7 @@ public class DRDesignMap extends DRDesignComponent implements DRIDesignMap {
         super("map");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -66,9 +64,7 @@ public class DRDesignMap extends DRDesignComponent implements DRIDesignMap {
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getEvaluationGroup() {
         return evaluationGroup;
@@ -83,9 +79,7 @@ public class DRDesignMap extends DRDesignComponent implements DRIDesignMap {
         this.evaluationGroup = evaluationGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLatitudeExpression() {
         return latitudeExpression;
@@ -100,9 +94,7 @@ public class DRDesignMap extends DRDesignComponent implements DRIDesignMap {
         this.latitudeExpression = latitudeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getLongitudeExpression() {
         return longitudeExpression;
@@ -117,9 +109,7 @@ public class DRDesignMap extends DRDesignComponent implements DRIDesignMap {
         this.longitudeExpression = longitudeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getZoomExpression() {
         return zoomExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignRectangle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignRectangle.java
@@ -44,9 +44,7 @@ public class DRDesignRectangle extends DRDesignComponent implements DRIDesignRec
         super("rectangle");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRadius() {
         return radius;
@@ -61,9 +59,7 @@ public class DRDesignRectangle extends DRDesignComponent implements DRIDesignRec
         this.radius = radius;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignSubreport.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignSubreport.java
@@ -47,9 +47,7 @@ public class DRDesignSubreport extends DRDesignComponent implements DRIDesignSub
         super("subreport");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getReportExpression() {
         return reportExpression;
@@ -64,9 +62,7 @@ public class DRDesignSubreport extends DRDesignComponent implements DRIDesignSub
         this.reportExpression = reportExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getParametersExpression() {
         return parametersExpression;
@@ -81,9 +77,7 @@ public class DRDesignSubreport extends DRDesignComponent implements DRIDesignSub
         this.parametersExpression = parametersExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getConnectionExpression() {
         return connectionExpression;
@@ -98,9 +92,7 @@ public class DRDesignSubreport extends DRDesignComponent implements DRIDesignSub
         this.connectionExpression = connectionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getDataSourceExpression() {
         return dataSourceExpression;
@@ -115,9 +107,7 @@ public class DRDesignSubreport extends DRDesignComponent implements DRIDesignSub
         this.dataSourceExpression = dataSourceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRunToBottom() {
         return runToBottom;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignTextField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/component/DRDesignTextField.java
@@ -55,9 +55,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         super("textField");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -72,9 +70,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getPatternExpression() {
         return patternExpression;
@@ -89,9 +85,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.patternExpression = patternExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -106,9 +100,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;
@@ -123,9 +115,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isPrintRepeatedValues() {
         return printRepeatedValues;
@@ -140,9 +130,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.printRepeatedValues = printRepeatedValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public EvaluationTime getEvaluationTime() {
         return evaluationTime;
@@ -157,9 +145,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getEvaluationGroup() {
         return evaluationGroup;
@@ -174,9 +160,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.evaluationGroup = evaluationGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Markup getMarkup() {
         return markup;
@@ -191,9 +175,7 @@ public class DRDesignTextField extends DRDesignHyperlinkComponent implements DRI
         this.markup = markup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isStretchWithOverflow() {
         return stretchWithOverflow;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstab.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstab.java
@@ -59,9 +59,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         super("crosstab");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
@@ -71,9 +69,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         measures = new ArrayList<DRIDesignCrosstabMeasure>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabDataset getDataset() {
         return dataset;
@@ -88,9 +84,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.dataset = dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean isRepeatColumnHeaders() {
         return repeatColumnHeaders;
@@ -105,9 +99,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.repeatColumnHeaders = repeatColumnHeaders;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean isRepeatRowHeaders() {
         return repeatRowHeaders;
@@ -122,9 +114,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.repeatRowHeaders = repeatRowHeaders;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnBreakOffset() {
         return columnBreakOffset;
@@ -139,9 +129,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.columnBreakOffset = columnBreakOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreWidth() {
         return ignoreWidth;
@@ -156,9 +144,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.ignoreWidth = ignoreWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getRunDirection() {
         return runDirection;
@@ -173,9 +159,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.runDirection = runDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabCellContent getWhenNoDataCell() {
         return whenNoDataCell;
@@ -190,9 +174,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.whenNoDataCell = whenNoDataCell;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabCellContent getHeaderCell() {
         return headerCell;
@@ -207,9 +189,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.headerCell = headerCell;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignCrosstabColumnGroup> getColumnGroups() {
         return columnGroups;
@@ -224,9 +204,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.columnGroups = columnGroups;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignCrosstabRowGroup> getRowGroups() {
         return rowGroups;
@@ -241,9 +219,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.rowGroups = rowGroups;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignCrosstabCell> getCells() {
         return cells;
@@ -258,9 +234,7 @@ public class DRDesignCrosstab extends DRDesignComponent implements DRIDesignCros
         this.cells = cells;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignCrosstabMeasure> getMeasures() {
         return measures;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabCell.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabCell.java
@@ -38,9 +38,7 @@ public class DRDesignCrosstabCell implements DRIDesignCrosstabCell {
     private String columnTotalGroup;
     private DRDesignCrosstabCellContent content;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -55,9 +53,7 @@ public class DRDesignCrosstabCell implements DRIDesignCrosstabCell {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getRowTotalGroup() {
         return rowTotalGroup;
@@ -72,9 +68,7 @@ public class DRDesignCrosstabCell implements DRIDesignCrosstabCell {
         this.rowTotalGroup = rowTotalGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getColumnTotalGroup() {
         return columnTotalGroup;
@@ -89,9 +83,7 @@ public class DRDesignCrosstabCell implements DRIDesignCrosstabCell {
         this.columnTotalGroup = columnTotalGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabCellContent getContent() {
         return content;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabCellContent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabCellContent.java
@@ -42,9 +42,7 @@ public class DRDesignCrosstabCellContent implements DRIDesignCrosstabCellContent
     private DRDesignComponent component;
     private DRIDesignStyle style;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getWidth() {
         return width;
@@ -59,9 +57,7 @@ public class DRDesignCrosstabCellContent implements DRIDesignCrosstabCellContent
         this.width = width;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getHeight() {
         return height;
@@ -94,9 +90,7 @@ public class DRDesignCrosstabCellContent implements DRIDesignCrosstabCellContent
         this.list = list;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignComponent getComponent() {
         return component;
@@ -111,9 +105,7 @@ public class DRDesignCrosstabCellContent implements DRIDesignCrosstabCellContent
         this.component = component;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignStyle getStyle() {
         return style;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabColumnGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabColumnGroup.java
@@ -35,9 +35,7 @@ public class DRDesignCrosstabColumnGroup extends DRDesignCrosstabGroup implement
 
     private int height;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getHeight() {
         return height;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabDataset.java
@@ -41,9 +41,7 @@ public class DRDesignCrosstabDataset implements DRIDesignCrosstabDataset {
     private ResetType resetType;
     private DRDesignGroup resetGroup;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignDataset getSubDataset() {
         return subDataset;
@@ -58,9 +56,7 @@ public class DRDesignCrosstabDataset implements DRIDesignCrosstabDataset {
         this.subDataset = subDataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDataPreSorted() {
         return dataPreSorted;
@@ -75,9 +71,7 @@ public class DRDesignCrosstabDataset implements DRIDesignCrosstabDataset {
         this.dataPreSorted = dataPreSorted;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ResetType getResetType() {
         return resetType;
@@ -92,9 +86,7 @@ public class DRDesignCrosstabDataset implements DRIDesignCrosstabDataset {
         this.resetType = resetType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignGroup getResetGroup() {
         return resetGroup;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabGroup.java
@@ -45,9 +45,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
     private DRDesignCrosstabCellContent header;
     private DRDesignCrosstabCellContent totalHeader;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -62,9 +60,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabTotalPosition getTotalPosition() {
         return totalPosition;
@@ -79,9 +75,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.totalPosition = totalPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OrderType getOrderType() {
         return orderType;
@@ -96,9 +90,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.orderType = orderType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getExpression() {
         return expression;
@@ -113,9 +105,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.expression = expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getOrderByExpression() {
         return orderByExpression;
@@ -130,9 +120,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.orderByExpression = orderByExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getComparatorExpression() {
         return comparatorExpression;
@@ -147,9 +135,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.comparatorExpression = comparatorExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabCellContent getHeader() {
         return header;
@@ -164,9 +150,7 @@ public abstract class DRDesignCrosstabGroup implements DRIDesignCrosstabGroup {
         this.header = header;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignCrosstabCellContent getTotalHeader() {
         return totalHeader;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabMeasure.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabMeasure.java
@@ -42,9 +42,7 @@ public class DRDesignCrosstabMeasure implements DRIDesignCrosstabMeasure {
     private Calculation calculation;
     private CrosstabPercentageType percentageType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -59,9 +57,7 @@ public class DRDesignCrosstabMeasure implements DRIDesignCrosstabMeasure {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;
@@ -76,9 +72,7 @@ public class DRDesignCrosstabMeasure implements DRIDesignCrosstabMeasure {
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Calculation getCalculation() {
         return calculation;
@@ -93,9 +87,7 @@ public class DRDesignCrosstabMeasure implements DRIDesignCrosstabMeasure {
         this.calculation = calculation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabPercentageType getPercentageType() {
         return percentageType;
@@ -110,9 +102,7 @@ public class DRDesignCrosstabMeasure implements DRIDesignCrosstabMeasure {
         this.percentageType = percentageType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         if (percentageType != null && percentageType.equals(CrosstabPercentageType.GRAND_TOTAL) && !calculation.equals(Calculation.COUNT) && !calculation.equals(Calculation.DISTINCT_COUNT)) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabRowGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/crosstab/DRDesignCrosstabRowGroup.java
@@ -35,9 +35,7 @@ public class DRDesignCrosstabRowGroup extends DRDesignCrosstabGroup implements D
 
     private int width;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getWidth() {
         return width;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/AbstractDesignComplexExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/AbstractDesignComplexExpression.java
@@ -58,9 +58,7 @@ public abstract class AbstractDesignComplexExpression implements DRIDesignComple
         this.expressions = new ArrayList<DRIDesignExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -75,9 +73,7 @@ public abstract class AbstractDesignComplexExpression implements DRIDesignComple
         this.expressions.add(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignExpression> getExpressions() {
         return expressions;
@@ -92,9 +88,7 @@ public abstract class AbstractDesignComplexExpression implements DRIDesignComple
         this.expressions = expressions;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getParameterName() {
         return null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/AbstractDesignSimpleExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/AbstractDesignSimpleExpression.java
@@ -52,17 +52,13 @@ public abstract class AbstractDesignSimpleExpression implements DRIDesignSimpleE
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getParameterName() {
         return null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignComplexExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignComplexExpression.java
@@ -50,33 +50,25 @@ public class DRDesignComplexExpression extends AbstractDesignComplexExpression {
         this.parameterName = parameterName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(List<?> values, ReportParameters reportParameters) {
         return complexExpression.evaluate(values, reportParameters);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return complexExpression.getValueClass();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return complexExpression.getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getParameterName() {
         return parameterName;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignJasperExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignJasperExpression.java
@@ -45,25 +45,19 @@ public class DRDesignJasperExpression implements DRIDesignJasperExpression {
         this.jasperExpression = jasperExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getExpression() {
         return jasperExpression.getExpression();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return jasperExpression.getValueClass();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return jasperExpression.getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignParameterExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignParameterExpression.java
@@ -37,9 +37,7 @@ public class DRDesignParameterExpression implements DRIDesignParameterExpression
     private String name;
     private DRIDesignExpression valueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -54,9 +52,7 @@ public class DRDesignParameterExpression implements DRIDesignParameterExpression
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignPropertyExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignPropertyExpression.java
@@ -37,9 +37,7 @@ public class DRDesignPropertyExpression implements DRIDesignPropertyExpression {
     private String name;
     private DRIDesignExpression valueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -54,9 +52,7 @@ public class DRDesignPropertyExpression implements DRIDesignPropertyExpression {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignSimpleExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignSimpleExpression.java
@@ -48,33 +48,25 @@ public class DRDesignSimpleExpression extends AbstractDesignSimpleExpression {
         this.parameterName = parameterName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(ReportParameters reportParameters) {
         return simpleExpression.evaluate(reportParameters);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return simpleExpression.getValueClass();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return simpleExpression.getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getParameterName() {
         return parameterName;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignSystemExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignSystemExpression.java
@@ -45,17 +45,13 @@ public class DRDesignSystemExpression implements DRIDesignSystemExpression {
         this.systemExpression = systemExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return systemExpression.getValueClass();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return systemExpression.getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignValueFormatter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/expression/DRDesignValueFormatter.java
@@ -41,26 +41,23 @@ public class DRDesignValueFormatter extends AbstractDesignComplexExpression {
 
     @SuppressWarnings("unchecked")
     /**
-     * <p>Constructor for DRDesignValueFormatter.</p>
+     * Constructor for DRDesignValueFormatter.
      *
      * @param valueFormatter a {@link net.sf.dynamicreports.report.definition.expression.DRIValueFormatter} object.
      * @param valueExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignExpression} object.
-     */ public DRDesignValueFormatter(DRIValueFormatter<?, ?> valueFormatter, DRIDesignExpression valueExpression) {
+     */
+    public DRDesignValueFormatter(DRIValueFormatter<?, ?> valueFormatter, DRIDesignExpression valueExpression) {
         this.valueFormatter = (DRIValueFormatter<?, Object>) valueFormatter;
         addExpression(valueExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(List<?> values, ReportParameters reportParameters) {
         return valueFormatter.format(values.get(0), reportParameters);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return valueFormatter.getValueClass();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignBaseStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignBaseStyle.java
@@ -60,9 +60,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
     private DRDesignParagraph paragraph;
     private DRDesignPen linePen;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getForegroundColor() {
         return foregroundColor;
@@ -77,9 +75,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.foregroundColor = foregroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -94,9 +90,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRadius() {
         return radius;
@@ -111,9 +105,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.radius = radius;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageScale getImageScale() {
         return imageScale;
@@ -128,9 +120,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.imageScale = imageScale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -145,9 +135,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalTextAlignment getVerticalTextAlignment() {
         return verticalTextAlignment;
@@ -162,9 +150,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.verticalTextAlignment = verticalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalImageAlignment getHorizontalImageAlignment() {
         return horizontalImageAlignment;
@@ -179,9 +165,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.horizontalImageAlignment = horizontalImageAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalImageAlignment getVerticalImageAlignment() {
         return verticalImageAlignment;
@@ -196,9 +180,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.verticalImageAlignment = verticalImageAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignBorder getBorder() {
         return border;
@@ -213,9 +195,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.border = border;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPadding getPadding() {
         return padding;
@@ -230,9 +210,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.padding = padding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignFont getFont() {
         return font;
@@ -247,9 +225,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Rotation getRotation() {
         return rotation;
@@ -264,9 +240,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.rotation = rotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -281,9 +255,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Markup getMarkup() {
         return markup;
@@ -298,9 +270,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.markup = markup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignParagraph getParagraph() {
         return paragraph;
@@ -315,9 +285,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.paragraph = paragraph;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getLinePen() {
         return linePen;
@@ -332,9 +300,7 @@ public abstract class DRDesignBaseStyle implements DRIDesignBaseStyle {
         this.linePen = linePen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignBorder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignBorder.java
@@ -39,9 +39,7 @@ public class DRDesignBorder implements DRIDesignBorder {
     private DRDesignPen bottomPen;
     private DRDesignPen rightPen;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getTopPen() {
         return topPen;
@@ -56,9 +54,7 @@ public class DRDesignBorder implements DRIDesignBorder {
         this.topPen = topPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getLeftPen() {
         return leftPen;
@@ -73,9 +69,7 @@ public class DRDesignBorder implements DRIDesignBorder {
         this.leftPen = leftPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getBottomPen() {
         return bottomPen;
@@ -90,9 +84,7 @@ public class DRDesignBorder implements DRIDesignBorder {
         this.bottomPen = bottomPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignPen getRightPen() {
         return rightPen;
@@ -107,9 +99,7 @@ public class DRDesignBorder implements DRIDesignBorder {
         this.rightPen = rightPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignConditionalStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignConditionalStyle.java
@@ -39,9 +39,7 @@ public class DRDesignConditionalStyle extends DRDesignBaseStyle implements DRIDe
     private DRIDesignExpression conditionExpression;
     private DRIDesignDataset dataset;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignExpression getConditionExpression() {
         return conditionExpression;
@@ -56,9 +54,7 @@ public class DRDesignConditionalStyle extends DRDesignBaseStyle implements DRIDe
         this.conditionExpression = conditionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignDataset getDataset() {
         return dataset;
@@ -73,9 +69,7 @@ public class DRDesignConditionalStyle extends DRDesignBaseStyle implements DRIDe
         this.dataset = dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         EqualsBuilder equalsBuilder = new EqualsBuilder().appendSuper(super.equals(obj));

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignFont.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignFont.java
@@ -44,9 +44,7 @@ public class DRDesignFont implements DRIDesignFont {
     private String pdfEncoding;
     private Boolean pdfEmbedded;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getFontName() {
         return fontName;
@@ -61,9 +59,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.fontName = fontName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getBold() {
         return bold;
@@ -78,9 +74,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.bold = bold;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getItalic() {
         return italic;
@@ -95,9 +89,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.italic = italic;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUnderline() {
         return underline;
@@ -112,9 +104,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.underline = underline;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStrikeThrough() {
         return strikeThrough;
@@ -129,9 +119,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.strikeThrough = strikeThrough;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFontSize() {
         return fontSize;
@@ -146,9 +134,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.fontSize = fontSize;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPdfFontName() {
         return pdfFontName;
@@ -163,9 +149,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.pdfFontName = pdfFontName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPdfEncoding() {
         return pdfEncoding;
@@ -180,9 +164,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.pdfEncoding = pdfEncoding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPdfEmbedded() {
         return pdfEmbedded;
@@ -197,9 +179,7 @@ public class DRDesignFont implements DRIDesignFont {
         this.pdfEmbedded = pdfEmbedded;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignPadding.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignPadding.java
@@ -39,9 +39,7 @@ public class DRDesignPadding implements DRIDesignPadding {
     private Integer bottom;
     private Integer right;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTop() {
         return top;
@@ -56,9 +54,7 @@ public class DRDesignPadding implements DRIDesignPadding {
         this.top = top;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getLeft() {
         return left;
@@ -73,9 +69,7 @@ public class DRDesignPadding implements DRIDesignPadding {
         this.left = left;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBottom() {
         return bottom;
@@ -90,9 +84,7 @@ public class DRDesignPadding implements DRIDesignPadding {
         this.bottom = bottom;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRight() {
         return right;
@@ -107,9 +99,7 @@ public class DRDesignPadding implements DRIDesignPadding {
         this.right = right;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignParagraph.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignParagraph.java
@@ -48,9 +48,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
     private Integer tabStopWidth;
     private List<DRIDesignTabStop> tabStops;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineSpacing getLineSpacing() {
         return lineSpacing;
@@ -65,9 +63,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.lineSpacing = lineSpacing;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getLineSpacingSize() {
         return lineSpacingSize;
@@ -82,9 +78,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.lineSpacingSize = lineSpacingSize;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFirstLineIndent() {
         return firstLineIndent;
@@ -99,9 +93,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.firstLineIndent = firstLineIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getLeftIndent() {
         return leftIndent;
@@ -116,9 +108,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.leftIndent = leftIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRightIndent() {
         return rightIndent;
@@ -133,9 +123,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.rightIndent = rightIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSpacingBefore() {
         return spacingBefore;
@@ -150,9 +138,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.spacingBefore = spacingBefore;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSpacingAfter() {
         return spacingAfter;
@@ -167,9 +153,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.spacingAfter = spacingAfter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTabStopWidth() {
         return tabStopWidth;
@@ -184,9 +168,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.tabStopWidth = tabStopWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIDesignTabStop> getTabStops() {
         return tabStops;
@@ -201,9 +183,7 @@ public class DRDesignParagraph implements DRIDesignParagraph {
         this.tabStops = tabStops;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignPen.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignPen.java
@@ -41,9 +41,7 @@ public class DRDesignPen implements DRIDesignPen {
     private LineStyle lineStyle;
     private Color lineColor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getLineWidth() {
         return lineWidth;
@@ -58,9 +56,7 @@ public class DRDesignPen implements DRIDesignPen {
         this.lineWidth = lineWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineStyle getLineStyle() {
         return lineStyle;
@@ -75,9 +71,7 @@ public class DRDesignPen implements DRIDesignPen {
         this.lineStyle = lineStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLineColor() {
         return lineColor;
@@ -92,9 +86,7 @@ public class DRDesignPen implements DRIDesignPen {
         this.lineColor = lineColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignStyle.java
@@ -60,17 +60,13 @@ public class DRDesignStyle extends DRDesignBaseStyle implements DRIDesignStyle {
         this.conditionalStyles = new ArrayList<DRDesignConditionalStyle>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDesignStyle getParentStyle() {
         return parentStyle;
@@ -85,9 +81,7 @@ public class DRDesignStyle extends DRDesignBaseStyle implements DRIDesignStyle {
         this.parentStyle = parentStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRDesignConditionalStyle> getConditionalStyles() {
         return conditionalStyles;
@@ -111,9 +105,7 @@ public class DRDesignStyle extends DRDesignBaseStyle implements DRIDesignStyle {
         this.conditionalStyles.add(conditionalStyle);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         EqualsBuilder equalsBuilder = new EqualsBuilder().appendSuper(super.equals(obj));

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignTabStop.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/base/style/DRDesignTabStop.java
@@ -38,9 +38,7 @@ public class DRDesignTabStop implements DRIDesignTabStop {
     private int position;
     private TabStopAlignment alignment;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPosition() {
         return position;
@@ -55,9 +53,7 @@ public class DRDesignTabStop implements DRIDesignTabStop {
         this.position = position;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TabStopAlignment getAlignment() {
         return alignment;
@@ -72,9 +68,7 @@ public class DRDesignTabStop implements DRIDesignTabStop {
         this.alignment = alignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/BandTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/BandTransform.java
@@ -215,6 +215,7 @@ public class BandTransform {
      * <p>band.</p>
      *
      * @param bandName                   a {@link java.lang.String} object.
+     * @param bandName                   a {@link java.lang.String} object.
      * @param band                       a {@link net.sf.dynamicreports.report.definition.DRIBand} object.
      * @param splitType                  a {@link net.sf.dynamicreports.report.constant.SplitType} object.
      * @param defaultStyle               a {@link net.sf.dynamicreports.report.definition.style.DRIReportStyle} object.
@@ -244,6 +245,7 @@ public class BandTransform {
     /**
      * <p>band.</p>
      *
+     * @param bandName                   a {@link java.lang.String} object.
      * @param bandName                   a {@link java.lang.String} object.
      * @param band                       a {@link net.sf.dynamicreports.report.definition.DRIBand} object.
      * @param splitType                  a {@link net.sf.dynamicreports.report.constant.SplitType} object.

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/CustomBatikRenderer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/CustomBatikRenderer.java
@@ -56,9 +56,7 @@ public class CustomBatikRenderer extends WrappingSvgDataToGraphics2DRenderer {
         this.dimension = new Dimension(width, height);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Dimension2D getDimension(JasperReportsContext jasperReportsContext) {
         return dimension;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/DatasetExpressionTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/DatasetExpressionTransform.java
@@ -50,41 +50,31 @@ public class DatasetExpressionTransform extends AbstractExpressionTransform {
         this.dataset = dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected ResetType getVariableResetType(DRIVariable<?> variable) {
         return ResetType.REPORT;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRIField<?>> transformFields() {
         return dataset.getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRIVariable<?>> transformVariables() {
         return dataset.getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRISort> transformSorts() {
         return dataset.getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected DRIDesignDataset getDataset() {
         return accessor.getDatasetTransform().getDesignDataset(dataset);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/MainDatasetExpressionTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/MainDatasetExpressionTransform.java
@@ -50,9 +50,7 @@ public class MainDatasetExpressionTransform extends AbstractExpressionTransform 
         super(accessor);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void transform() throws DRException {
         DRIReport report = accessor.getReport();
@@ -66,49 +64,37 @@ public class MainDatasetExpressionTransform extends AbstractExpressionTransform 
         super.transform();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected ResetType getVariableResetType(DRIVariable<?> variable) {
         return ConstantTransform.variableResetType(variable.getResetType(), variable.getResetGroup(), accessor);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected DRDesignGroup getVariableResetGroup(DRIVariable<?> variable) throws DRException {
         return accessor.getGroupTransform().getGroup(ConstantTransform.variableResetGroup(variable.getName(), variable.getResetType(), variable.getResetGroup(), accessor));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRIField<?>> transformFields() {
         return accessor.getReport().getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRIVariable<?>> transformVariables() {
         return accessor.getReport().getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected List<? extends DRISort> transformSorts() {
         return accessor.getReport().getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected DRIDesignDataset getDataset() {
         return null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/TemplateTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/TemplateTransform.java
@@ -1578,6 +1578,7 @@ public class TemplateTransform {
      *
      * @param image       a {@link net.sf.dynamicreports.report.definition.component.DRIImage} object.
      * @param imageHeight a {@link java.lang.Integer} object.
+     * @param imageHeight a {@link java.lang.Integer} object.
      * @param style       a {@link net.sf.dynamicreports.design.base.style.DRDesignStyle} object.
      * @return a int.
      */

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/DifferenceRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/DifferenceRendererCustomizer.java
@@ -56,9 +56,7 @@ public class DifferenceRendererCustomizer implements DRIChartCustomizer, Seriali
         this.showShapes = differencePlot.getShowShapes();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         XYLineAndShapeRenderer lineRenderer = (XYLineAndShapeRenderer) chart.getXYPlot().getRenderer();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/GroupedStackedBarRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/GroupedStackedBarRendererCustomizer.java
@@ -60,9 +60,7 @@ public class GroupedStackedBarRendererCustomizer implements DRIChartCustomizer, 
     private KeyToGroupMap map;
     private Map<String, Paint> seriesColors;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         this.seriesColors = new LinkedHashMap<String, Paint>();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/LayeredBarRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/LayeredBarRendererCustomizer.java
@@ -54,9 +54,7 @@ public class LayeredBarRendererCustomizer implements DRIChartCustomizer, Seriali
         this.seriesBarWidths = seriesBarWidths;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         BarRenderer categoryRenderer = (BarRenderer) chart.getCategoryPlot().getRenderer();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PercentageCategoryDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PercentageCategoryDataset.java
@@ -49,84 +49,64 @@ public class PercentageCategoryDataset implements CategoryDataset, Serializable 
         this.dataset = dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparable<?> getRowKey(int row) {
         return dataset.getRowKey(row);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public int getRowIndex(Comparable key) {
         return dataset.getRowIndex(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<?> getRowKeys() {
         return dataset.getRowKeys();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparable<?> getColumnKey(int column) {
         return dataset.getColumnKey(column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public int getColumnIndex(Comparable key) {
         return dataset.getColumnIndex(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<?> getColumnKeys() {
         return dataset.getColumnKeys();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public Number getValue(Comparable rowKey, Comparable columnKey) {
         return getValue(getRowIndex(rowKey), getColumnIndex(columnKey));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getRowCount() {
         return dataset.getRowCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnCount() {
         return dataset.getColumnCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Number getValue(int row, int column) {
         double total = 0;
@@ -147,33 +127,25 @@ public class PercentageCategoryDataset implements CategoryDataset, Serializable 
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void addChangeListener(DatasetChangeListener listener) {
         dataset.addChangeListener(listener);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void removeChangeListener(DatasetChangeListener listener) {
         dataset.removeChangeListener(listener);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DatasetGroup getGroup() {
         return dataset.getGroup();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setGroup(DatasetGroup group) {
         dataset.setGroup(group);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PercentageGroupedCategoryDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PercentageGroupedCategoryDataset.java
@@ -43,9 +43,7 @@ public class PercentageGroupedCategoryDataset extends PercentageCategoryDataset 
         super(dataset);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Number getValue(int row, int column) {
         double total = 0;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PieChartLabelFormatCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/PieChartLabelFormatCustomizer.java
@@ -57,9 +57,7 @@ public class PieChartLabelFormatCustomizer implements DRIChartCustomizer, Serial
         this.percentValuePattern = percentValuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         PiePlot plot = (PiePlot) chart.getPlot();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesColorsByNameCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesColorsByNameCustomizer.java
@@ -63,9 +63,7 @@ public class SeriesColorsByNameCustomizer implements DRIChartCustomizer {
         this.seriesColorsByName = seriesColorsByName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         if (chart.getPlot() instanceof CategoryPlot) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesOrderCategoryDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesOrderCategoryDataset.java
@@ -69,117 +69,89 @@ public class SeriesOrderCategoryDataset implements CategoryDataset, Serializable
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparable<?> getRowKey(int row) {
         return rowKeys.get(row);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public int getRowIndex(Comparable key) {
         return rowKeys.indexOf(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<?> getRowKeys() {
         return rowKeys;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparable<?> getColumnKey(int column) {
         return dataset.getColumnKey(column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public int getColumnIndex(Comparable key) {
         return dataset.getColumnIndex(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<?> getColumnKeys() {
         return dataset.getColumnKeys();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("rawtypes")
     public Number getValue(Comparable rowKey, Comparable columnKey) {
         return getValue(getRowIndex(rowKey), getColumnIndex(columnKey));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getRowCount() {
         return dataset.getRowCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnCount() {
         return dataset.getColumnCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Number getValue(int row, int column) {
         int rowIndex = dataset.getRowIndex(rowKeys.get(row));
         return dataset.getValue(rowIndex, column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void addChangeListener(DatasetChangeListener listener) {
         dataset.addChangeListener(listener);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void removeChangeListener(DatasetChangeListener listener) {
         dataset.removeChangeListener(listener);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DatasetGroup getGroup() {
         return dataset.getGroup();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setGroup(DatasetGroup group) {
         dataset.setGroup(group);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesOrderCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/SeriesOrderCustomizer.java
@@ -55,9 +55,7 @@ public class SeriesOrderCustomizer implements DRIChartCustomizer, Serializable {
         this.seriesOrderType = seriesOrderType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         if (chart.getPlot() instanceof CategoryPlot) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/ShowPercentagesCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/ShowPercentagesCustomizer.java
@@ -41,9 +41,7 @@ import java.io.Serializable;
 public class ShowPercentagesCustomizer implements DRIChartCustomizer, Serializable {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         if (chart.getPlot() instanceof CategoryPlot) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/ShowValuesCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/ShowValuesCustomizer.java
@@ -64,9 +64,7 @@ public class ShowValuesCustomizer implements DRIChartCustomizer, Serializable {
         this.customRangeMaxValue = customRangeMaxValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         if (chart.getPlot() instanceof CategoryPlot) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/WaterfallBarRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/WaterfallBarRendererCustomizer.java
@@ -60,9 +60,7 @@ public class WaterfallBarRendererCustomizer implements DRIChartCustomizer, Seria
         this.negativeBarPaint = waterfallBarPlot.getNegativeBarPaint();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         BarRenderer categoryRenderer = (BarRenderer) chart.getCategoryPlot().getRenderer();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/XyBlockRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/XyBlockRendererCustomizer.java
@@ -55,9 +55,7 @@ public class XyBlockRendererCustomizer implements DRIChartCustomizer, Serializab
         this.xyBlockPlot = xyBlockPlot;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         chart.getXYPlot().getDomainAxis().setUpperMargin(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/XyStepRendererCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/chartcustomizer/XyStepRendererCustomizer.java
@@ -50,9 +50,7 @@ public class XyStepRendererCustomizer implements DRIChartCustomizer, Serializabl
         this.stepPoint = stepPoint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, ReportParameters reportParameters) {
         XYLineAndShapeRenderer lineRenderer = (XYLineAndShapeRenderer) chart.getXYPlot().getRenderer();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/BooleanImageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/BooleanImageExpression.java
@@ -101,9 +101,7 @@ public class BooleanImageExpression extends AbstractComplexExpression<Renderable
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Renderable evaluate(List<?> values, ReportParameters reportParameters) {
         Boolean value = (Boolean) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/BooleanTextValueFormatter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/BooleanTextValueFormatter.java
@@ -53,9 +53,7 @@ public class BooleanTextValueFormatter extends AbstractValueFormatter<String, Bo
         this.emptyWhenNullValue = emptyWhenNullValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String format(Boolean value, ReportParameters reportParameters) {
         if (emptyWhenNullValue && value == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabExpression.java
@@ -69,9 +69,7 @@ public class CrosstabExpression<T> extends AbstractComplexExpression<T> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
     public T evaluate(List<?> values, ReportParameters reportParameters) {
@@ -87,9 +85,7 @@ public class CrosstabExpression<T> extends AbstractComplexExpression<T> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @SuppressWarnings( {"rawtypes", "unchecked"})
     @Override
     public Class getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabMeasureExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabMeasureExpression.java
@@ -46,9 +46,7 @@ public class CrosstabMeasureExpression extends AbstractComplexExpression<Double>
         addExpression(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double evaluate(List<?> values, ReportParameters reportParameters) {
         Number value = (Number) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabPrintInEvenRow.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabPrintInEvenRow.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class CrosstabPrintInEvenRow extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getCrosstabRowNumber() % 2 == 0;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabPrintInOddRow.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabPrintInOddRow.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class CrosstabPrintInOddRow extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getCrosstabRowNumber() % 2 != 0;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabRowCount.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabRowCount.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class CrosstabRowCount extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         CrosstabRowCounter counter = reportParameters.getValue(ReportParameters.CROSSTAB_ROW_COUNTER);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabRowCounter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CrosstabRowCounter.java
@@ -36,9 +36,7 @@ public class CrosstabRowCounter extends AbstractSimpleExpression<CrosstabRowCoun
 
     private int rowNumber = 1;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabRowCounter evaluate(ReportParameters reportParameters) {
         return this;
@@ -60,9 +58,7 @@ public class CrosstabRowCounter extends AbstractSimpleExpression<CrosstabRowCoun
         return rowNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return ReportParameters.CROSSTAB_ROW_COUNTER;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CurrentDateExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/CurrentDateExpression.java
@@ -55,9 +55,7 @@ public class CurrentDateExpression extends AbstractComplexExpression<String> {
         addExpression(currentDateExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String pattern = (String) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/GroupByDataTypeExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/GroupByDataTypeExpression.java
@@ -49,9 +49,7 @@ public class GroupByDataTypeExpression extends AbstractSimpleExpression<String> 
         this.dataType = dataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(ReportParameters reportParameters) {
         return dataType.valueToString(valueExpression.getName(), reportParameters);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/GroupedSeriesExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/GroupedSeriesExpression.java
@@ -64,9 +64,7 @@ public class GroupedSeriesExpression extends AbstractComplexExpression<String> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String group = (String) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/MultiPageListDataSourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/MultiPageListDataSourceExpression.java
@@ -47,17 +47,13 @@ public class MultiPageListDataSourceExpression extends AbstractSimpleExpression<
         this.count = count;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JRDataSource evaluate(ReportParameters reportParameters) {
         return new JREmptyDataSource(count);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<JRDataSource> getValueClass() {
         return JRDataSource.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/MultiPageListSubreportExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/MultiPageListSubreportExpression.java
@@ -60,6 +60,7 @@ public class MultiPageListSubreportExpression extends AbstractSimpleExpression<J
      * @param locale                  a {@link java.util.Locale} object.
      * @param resourceBundle          a {@link java.util.ResourceBundle} object.
      * @param resourceBundleName      a {@link java.lang.String} object.
+     * @param resourceBundleName      a {@link java.lang.String} object.
      * @param whenResourceMissingType a {@link net.sf.dynamicreports.report.constant.WhenResourceMissingType} object.
      * @param detailComponents        a {@link java.util.List} object.
      * @param templateStyles          a {@link java.util.Map} object.
@@ -74,9 +75,7 @@ public class MultiPageListSubreportExpression extends AbstractSimpleExpression<J
         this.templateStyles = templateStyles;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperReportBuilder evaluate(ReportParameters reportParameters) {
         JasperReportBuilder report = report();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/PageNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/PageNumberExpression.java
@@ -47,9 +47,7 @@ public class PageNumberExpression extends AbstractComplexExpression<String> {
         addExpression(pageNumberFormatExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String pattern = (String) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/PageXofYNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/PageXofYNumberExpression.java
@@ -53,9 +53,7 @@ public class PageXofYNumberExpression extends AbstractComplexExpression<String> 
         this.index = index;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String pattern = (String) values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/SerieValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/SerieValueExpression.java
@@ -66,9 +66,7 @@ public class SerieValueExpression extends AbstractSimpleExpression<Number> {
         this.key = key;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Number evaluate(ReportParameters reportParameters) {
         if (reportParameters.getReportRowNumber() <= 1) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocPrintWhenExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocPrintWhenExpression.java
@@ -48,9 +48,7 @@ public class TocPrintWhenExpression extends AbstractComplexExpression<Boolean> {
         addExpression(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(List<?> values, ReportParameters reportParameters) {
         Object value = values.get(0);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocReferenceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocReferenceExpression.java
@@ -66,9 +66,7 @@ public class TocReferenceExpression extends AbstractComplexExpression<String> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String id;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocReferenceLinkExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/design/transformation/expressions/TocReferenceLinkExpression.java
@@ -54,9 +54,7 @@ public class TocReferenceLinkExpression extends AbstractComplexExpression<String
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(List<?> values, ReportParameters reportParameters) {
         String id;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/CustomScriptlet.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/CustomScriptlet.java
@@ -44,81 +44,61 @@ public class CustomScriptlet extends JRAbstractScriptlet {
         this.scriptlet = scriptlet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterColumnInit() throws JRScriptletException {
         scriptlet.afterColumnInit(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterDetailEval() throws JRScriptletException {
         scriptlet.afterDetailEval(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterGroupInit(String groupName) throws JRScriptletException {
         scriptlet.afterGroupInit(groupName, getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterPageInit() throws JRScriptletException {
         scriptlet.afterPageInit(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterReportInit() throws JRScriptletException {
         scriptlet.afterReportInit(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeColumnInit() throws JRScriptletException {
         scriptlet.beforeColumnInit(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeDetailEval() throws JRScriptletException {
         scriptlet.beforeDetailEval(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeGroupInit(String groupName) throws JRScriptletException {
         scriptlet.beforeGroupInit(groupName, getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforePageInit() throws JRScriptletException {
         scriptlet.beforePageInit(getReportParameters());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeReportInit() throws JRScriptletException {
         scriptlet.beforeReportInit(getReportParameters());

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
@@ -21,17 +21,22 @@
 package net.sf.dynamicreports.jasper.base;
 
 /**
- * Simple, default implementation of {@link JasperScriptletManager}.
+ * Simple, default implementation of {@link net.sf.dynamicreports.jasper.base.JasperScriptletManager}.
+ *
+ * @author edwin.njeru
+ * @version 6.0.1-SNAPSHOT
  */
 public class DefaultJasperScriptletManager implements JasperScriptletManager {
 
     private JasperScriptlet jasperScriptlet;
 
+    /** {@inheritDoc} */
     @Override
     public JasperScriptlet getJasperScriptlet() {
         return jasperScriptlet;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
         this.jasperScriptlet = jasperScriptlet;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/DefaultJasperScriptletManager.java
@@ -25,16 +25,16 @@ package net.sf.dynamicreports.jasper.base;
  */
 public class DefaultJasperScriptletManager implements JasperScriptletManager {
 
-  private JasperScriptlet jasperScriptlet;
+    private JasperScriptlet jasperScriptlet;
 
-  @Override
-  public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
-    this.jasperScriptlet = jasperScriptlet;
-  }
+    @Override
+    public JasperScriptlet getJasperScriptlet() {
+        return jasperScriptlet;
+    }
 
-  @Override
-  public JasperScriptlet getJasperScriptlet() {
-    return jasperScriptlet;
-  }
+    @Override
+    public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+        this.jasperScriptlet = jasperScriptlet;
+    }
 
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperChartCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperChartCustomizer.java
@@ -36,9 +36,7 @@ import java.util.List;
  */
 public class JasperChartCustomizer extends JRAbstractChartCustomizer {
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize(JFreeChart chart, JRChart jasperChart) {
         String key = jasperChart.getKey();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
@@ -20,14 +20,6 @@
 
 package net.sf.dynamicreports.jasper.base;
 
-import static java.lang.Boolean.TRUE;
-import static net.sf.dynamicreports.jasper.base.JasperScriptletManager.USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression;
 import net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression;
 import net.sf.dynamicreports.jasper.base.tableofcontents.JasperTocHeading;
@@ -35,8 +27,15 @@ import net.sf.dynamicreports.jasper.constant.ValueType;
 import net.sf.dynamicreports.report.constant.Constants;
 import net.sf.dynamicreports.report.definition.DRICustomValues;
 import net.sf.dynamicreports.report.definition.chart.DRIChartCustomizer;
-
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.lang.Boolean.TRUE;
+import static net.sf.dynamicreports.jasper.base.JasperScriptletManager.USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY;
 
 /**
  * <p>
@@ -47,329 +46,323 @@ import org.apache.commons.lang3.StringUtils;
  * @version $Id: $Id
  */
 public class JasperCustomValues implements DRICustomValues {
-  private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
+    private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-  private Map<String, ValueType> valueTypes;
-  private Map<String, DRIDesignSimpleExpression> simpleExpressions;
-  private Map<String, DRIDesignComplexExpression> complexExpressions;
-  private Map<String, List<DRIChartCustomizer>> chartCustomizers;
-  private Map<String, Object> systemValues;
-  private Integer startPageNumber;
-  private Map<String, JasperTocHeading> tocHeadings;
-  private Integer subreportWidth;
-  private transient JasperScriptletManager scriptletManager;
+    private Map<String, ValueType> valueTypes;
+    private Map<String, DRIDesignSimpleExpression> simpleExpressions;
+    private Map<String, DRIDesignComplexExpression> complexExpressions;
+    private Map<String, List<DRIChartCustomizer>> chartCustomizers;
+    private Map<String, Object> systemValues;
+    private Integer startPageNumber;
+    private Map<String, JasperTocHeading> tocHeadings;
+    private Integer subreportWidth;
+    private transient JasperScriptletManager scriptletManager;
 
-  /**
-   * <p>
-   * Constructor for JasperCustomValues.
-   * </p>
-   */
-  public JasperCustomValues(Properties properties) {
-    init(properties);
-  }
-
-  private void init(Properties properties) {
-    valueTypes = new HashMap<>();
-    simpleExpressions = new HashMap<>();
-    complexExpressions = new HashMap<>();
-    chartCustomizers = new HashMap<>();
-    systemValues = new HashMap<>();
-    scriptletManager = createScriptletManager(properties);
-  }
-
-  private JasperScriptletManager createScriptletManager(Properties properties) {
-    String useThreadSafeScriptletManagerPropertyValue =
-        properties.getProperty(USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY);
-    if (TRUE.toString().equalsIgnoreCase(useThreadSafeScriptletManagerPropertyValue)) {
-      return new ThreadSafeJasperScriptletManager();
-    }
-    return new DefaultJasperScriptletManager();
-  }
-
-  /**
-   * <p>
-   * addSimpleExpression.
-   * </p>
-   *
-   * @param simpleExpression a
-   *        {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression}
-   *        object.
-   */
-  public void addSimpleExpression(DRIDesignSimpleExpression simpleExpression) {
-    simpleExpressions.put(simpleExpression.getName(), simpleExpression);
-    addValueType(simpleExpression.getName(), ValueType.SIMPLE_EXPRESSION);
-  }
-
-  /**
-   * <p>
-   * addComplexExpression.
-   * </p>
-   *
-   * @param complexExpression a
-   *        {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression}
-   *        object.
-   */
-  public void addComplexExpression(DRIDesignComplexExpression complexExpression) {
-    complexExpressions.put(complexExpression.getName(), complexExpression);
-    addValueType(complexExpression.getName(), ValueType.COMPLEX_EXPRESSION);
-  }
-
-  /**
-   * <p>
-   * addChartCustomizers.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @param chartCustomizers a {@link java.util.List} object.
-   */
-  public void addChartCustomizers(String name, List<DRIChartCustomizer> chartCustomizers) {
-    this.chartCustomizers.put(name, chartCustomizers);
-  }
-
-  /**
-   * <p>
-   * addValueType.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @param valueType a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
-   */
-  public void addValueType(String name, ValueType valueType) {
-    /*
-     * if (valueTypes.containsKey(name)) { throw new JasperDesignException("Duplicate value name \""
-     * + name + "\""); }
+    /**
+     * <p>
+     * Constructor for JasperCustomValues.
+     * </p>
      */
-    valueTypes.put(name, valueType);
-  }
-
-  /**
-   * <p>
-   * getValueType.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
-   */
-  protected ValueType getValueType(String name) {
-    return valueTypes.get(name);
-  }
-
-  /**
-   * <p>
-   * getSimpleExpression.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression}
-   *         object.
-   */
-  protected DRIDesignSimpleExpression getSimpleExpression(String name) {
-    return simpleExpressions.get(name);
-  }
-
-  /**
-   * <p>
-   * getComplexExpression.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression}
-   *         object.
-   */
-  protected DRIDesignComplexExpression getComplexExpression(String name) {
-    return complexExpressions.get(name);
-  }
-
-  /**
-   * <p>
-   * Getter for the field <code>chartCustomizers</code>.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link java.util.List} object.
-   */
-  protected List<DRIChartCustomizer> getChartCustomizers(String name) {
-    return chartCustomizers.get(name);
-  }
-
-  /**
-   * <p>
-   * isEmpty.
-   * </p>
-   *
-   * @return a boolean.
-   */
-  public boolean isEmpty() {
-    if (!simpleExpressions.isEmpty()) {
-      return false;
+    public JasperCustomValues(Properties properties) {
+        init(properties);
     }
-    if (!complexExpressions.isEmpty()) {
-      return false;
+
+    private void init(Properties properties) {
+        valueTypes = new HashMap<>();
+        simpleExpressions = new HashMap<>();
+        complexExpressions = new HashMap<>();
+        chartCustomizers = new HashMap<>();
+        systemValues = new HashMap<>();
+        scriptletManager = createScriptletManager(properties);
     }
-    if (!chartCustomizers.isEmpty()) {
-      return false;
+
+    private JasperScriptletManager createScriptletManager(Properties properties) {
+        String useThreadSafeScriptletManagerPropertyValue = properties.getProperty(USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY);
+        if (TRUE.toString().equalsIgnoreCase(useThreadSafeScriptletManagerPropertyValue)) {
+            return new ThreadSafeJasperScriptletManager();
+        }
+        return new DefaultJasperScriptletManager();
     }
-    return true;
-  }
 
-  /**
-   * <p>
-   * getValue.
-   * </p>
-   *
-   * @param valueName a {@link java.lang.String} object.
-   * @return a {@link java.lang.Object} object.
-   */
-  public Object getValue(String valueName) {
-    return scriptletManager.getJasperScriptlet().getValue(valueName);
-       
-  }
-
-  /**
-   * <p>
-   * getValue.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @param values an array of {@link java.lang.Object} objects.
-   * @return a {@link java.lang.Object} object.
-   */
-  public Object getValue(String name, Object[] values) {
-    return scriptletManager.getJasperScriptlet().getValue(name, values);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setSystemValue(String name, Object value) {
-    systemValues.put(name, value);
-  }
-
-  /**
-   * <p>
-   * getSystemValue.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link java.lang.Object} object.
-   */
-  protected Object getSystemValue(String name) {
-    return systemValues.get(name);
-  }
-
-  /**
-   * <p>
-   * Getter for the field <code>jasperScriptlet</code>.
-   * </p>
-   *
-   * @return a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
-   */
-  protected JasperScriptlet getJasperScriptlet() {
-    return scriptletManager.getJasperScriptlet();
-  }
-
-  /**
-   * <p>
-   * Setter for the field <code>jasperScriptlet</code>.
-   * </p>
-   *
-   * @param jasperScriptlet a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
-   */
-  protected void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
-    scriptletManager.setJasperScriptlet(jasperScriptlet);
-  }
-
-  /**
-   * <p>
-   * Getter for the field <code>startPageNumber</code>.
-   * </p>
-   *
-   * @return a {@link java.lang.Integer} object.
-   */
-  public Integer getStartPageNumber() {
-    return startPageNumber;
-  }
-
-  /**
-   * <p>
-   * Setter for the field <code>startPageNumber</code>.
-   * </p>
-   *
-   * @param startPageNumber a {@link java.lang.Integer} object.
-   */
-  public void setStartPageNumber(Integer startPageNumber) {
-    this.startPageNumber = startPageNumber;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void addTocHeading(int level, String id, String text, Object customValue) {
-    JasperTocHeading heading = new JasperTocHeading();
-    heading.setLevel(level);
-    heading.setText(text);
-    heading.setReference(id);
-    heading.setCustomValue(customValue);
-    tocHeadings.put(id, heading);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Map<String, JasperTocHeading> getTocHeadings() {
-    return tocHeadings;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setTocHeadings(Map<String, JasperTocHeading> tocHeadings) {
-    this.tocHeadings = tocHeadings;
-  }
-
-  /**
-   * <p>
-   * Getter for the field <code>subreportWidth</code>.
-   * </p>
-   *
-   * @return a {@link java.lang.Integer} object.
-   */
-  public Integer getSubreportWidth() {
-    return subreportWidth;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setSubreportWidth(Integer subreportWidth) {
-    this.subreportWidth = subreportWidth;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public String toString() {
-    StringBuilder result = new StringBuilder();
-    for (String name : valueTypes.keySet()) {
-      result.append(valueTypes.get(name).name() + ":" + name);
-      result.append(", ");
+    /**
+     * <p>
+     * addSimpleExpression.
+     * </p>
+     *
+     * @param simpleExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression} object.
+     */
+    public void addSimpleExpression(DRIDesignSimpleExpression simpleExpression) {
+        simpleExpressions.put(simpleExpression.getName(), simpleExpression);
+        addValueType(simpleExpression.getName(), ValueType.SIMPLE_EXPRESSION);
     }
-    return "{" + StringUtils.removeEnd(result.toString(), ", ") + "}";
-  }
 
-  /**
-   * Getter for testing purposes.
-   * @return the {@link JasperScriptletManager}
-   */
-  JasperScriptletManager getScriptletManager() {
-    return scriptletManager;
-  }
-  
-  
+    /**
+     * <p>
+     * addComplexExpression.
+     * </p>
+     *
+     * @param complexExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression} object.
+     */
+    public void addComplexExpression(DRIDesignComplexExpression complexExpression) {
+        complexExpressions.put(complexExpression.getName(), complexExpression);
+        addValueType(complexExpression.getName(), ValueType.COMPLEX_EXPRESSION);
+    }
+
+    /**
+     * <p>
+     * addChartCustomizers.
+     * </p>
+     *
+     * @param name             a {@link java.lang.String} object.
+     * @param chartCustomizers a {@link java.util.List} object.
+     */
+    public void addChartCustomizers(String name, List<DRIChartCustomizer> chartCustomizers) {
+        this.chartCustomizers.put(name, chartCustomizers);
+    }
+
+    /**
+     * <p>
+     * addValueType.
+     * </p>
+     *
+     * @param name      a {@link java.lang.String} object.
+     * @param valueType a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
+     */
+    public void addValueType(String name, ValueType valueType) {
+        /*
+         * if (valueTypes.containsKey(name)) { throw new JasperDesignException("Duplicate value name \""
+         * + name + "\""); }
+         */
+        valueTypes.put(name, valueType);
+    }
+
+    /**
+     * <p>
+     * getValueType.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link net.sf.dynamicreports.jasper.constant.ValueType} object.
+     */
+    protected ValueType getValueType(String name) {
+        return valueTypes.get(name);
+    }
+
+    /**
+     * <p>
+     * getSimpleExpression.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignSimpleExpression} object.
+     */
+    protected DRIDesignSimpleExpression getSimpleExpression(String name) {
+        return simpleExpressions.get(name);
+    }
+
+    /**
+     * <p>
+     * getComplexExpression.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignComplexExpression} object.
+     */
+    protected DRIDesignComplexExpression getComplexExpression(String name) {
+        return complexExpressions.get(name);
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>chartCustomizers</code>.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.util.List} object.
+     */
+    protected List<DRIChartCustomizer> getChartCustomizers(String name) {
+        return chartCustomizers.get(name);
+    }
+
+    /**
+     * <p>
+     * isEmpty.
+     * </p>
+     *
+     * @return a boolean.
+     */
+    public boolean isEmpty() {
+        if (!simpleExpressions.isEmpty()) {
+            return false;
+        }
+        if (!complexExpressions.isEmpty()) {
+            return false;
+        }
+        if (!chartCustomizers.isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * <p>
+     * getValue.
+     * </p>
+     *
+     * @param valueName a {@link java.lang.String} object.
+     * @return a {@link java.lang.Object} object.
+     */
+    public Object getValue(String valueName) {
+        return scriptletManager.getJasperScriptlet().getValue(valueName);
+
+    }
+
+    /**
+     * <p>
+     * getValue.
+     * </p>
+     *
+     * @param name   a {@link java.lang.String} object.
+     * @param values an array of {@link java.lang.Object} objects.
+     * @return a {@link java.lang.Object} object.
+     */
+    public Object getValue(String name, Object[] values) {
+        return scriptletManager.getJasperScriptlet().getValue(name, values);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSystemValue(String name, Object value) {
+        systemValues.put(name, value);
+    }
+
+    /**
+     * <p>
+     * getSystemValue.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.Object} object.
+     */
+    protected Object getSystemValue(String name) {
+        return systemValues.get(name);
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>jasperScriptlet</code>.
+     * </p>
+     *
+     * @return a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
+     */
+    protected JasperScriptlet getJasperScriptlet() {
+        return scriptletManager.getJasperScriptlet();
+    }
+
+    /**
+     * <p>
+     * Setter for the field <code>jasperScriptlet</code>.
+     * </p>
+     *
+     * @param jasperScriptlet a {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} object.
+     */
+    protected void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+        scriptletManager.setJasperScriptlet(jasperScriptlet);
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>startPageNumber</code>.
+     * </p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    public Integer getStartPageNumber() {
+        return startPageNumber;
+    }
+
+    /**
+     * <p>
+     * Setter for the field <code>startPageNumber</code>.
+     * </p>
+     *
+     * @param startPageNumber a {@link java.lang.Integer} object.
+     */
+    public void setStartPageNumber(Integer startPageNumber) {
+        this.startPageNumber = startPageNumber;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addTocHeading(int level, String id, String text, Object customValue) {
+        JasperTocHeading heading = new JasperTocHeading();
+        heading.setLevel(level);
+        heading.setText(text);
+        heading.setReference(id);
+        heading.setCustomValue(customValue);
+        tocHeadings.put(id, heading);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, JasperTocHeading> getTocHeadings() {
+        return tocHeadings;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTocHeadings(Map<String, JasperTocHeading> tocHeadings) {
+        this.tocHeadings = tocHeadings;
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>subreportWidth</code>.
+     * </p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    public Integer getSubreportWidth() {
+        return subreportWidth;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSubreportWidth(Integer subreportWidth) {
+        this.subreportWidth = subreportWidth;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        for (String name : valueTypes.keySet()) {
+            result.append(valueTypes.get(name).name() + ":" + name);
+            result.append(", ");
+        }
+        return "{" + StringUtils.removeEnd(result.toString(), ", ") + "}";
+    }
+
+    /**
+     * Getter for testing purposes.
+     *
+     * @return the {@link JasperScriptletManager}
+     */
+    JasperScriptletManager getScriptletManager() {
+        return scriptletManager;
+    }
+
+
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperCustomValues.java
@@ -62,6 +62,8 @@ public class JasperCustomValues implements DRICustomValues {
      * <p>
      * Constructor for JasperCustomValues.
      * </p>
+     *
+     * @param properties a {@link java.util.Properties} object.
      */
     public JasperCustomValues(Properties properties) {
         init(properties);
@@ -230,9 +232,7 @@ public class JasperCustomValues implements DRICustomValues {
         return scriptletManager.getJasperScriptlet().getValue(name, values);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setSystemValue(String name, Object value) {
         systemValues.put(name, value);
@@ -294,9 +294,7 @@ public class JasperCustomValues implements DRICustomValues {
         this.startPageNumber = startPageNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void addTocHeading(int level, String id, String text, Object customValue) {
         JasperTocHeading heading = new JasperTocHeading();
@@ -307,17 +305,13 @@ public class JasperCustomValues implements DRICustomValues {
         tocHeadings.put(id, heading);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, JasperTocHeading> getTocHeadings() {
         return tocHeadings;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setTocHeadings(Map<String, JasperTocHeading> tocHeadings) {
         this.tocHeadings = tocHeadings;
@@ -334,17 +328,13 @@ public class JasperCustomValues implements DRICustomValues {
         return subreportWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setSubreportWidth(Integer subreportWidth) {
         this.subreportWidth = subreportWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperReportParameters.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperReportParameters.java
@@ -66,9 +66,7 @@ public class JasperReportParameters implements ReportParameters {
         this.jasperScriptlet = jasperScriptlet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(String name) {
@@ -95,9 +93,7 @@ public class JasperReportParameters implements ReportParameters {
         throw new DRReportException("Value " + name + " not found");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getValue(DRIValue<T> value) {
@@ -106,9 +102,7 @@ public class JasperReportParameters implements ReportParameters {
 
     // field
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getFieldValue(String name) {
@@ -121,9 +115,7 @@ public class JasperReportParameters implements ReportParameters {
 
     // variable
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getVariableValue(String name) {
@@ -134,49 +126,37 @@ public class JasperReportParameters implements ReportParameters {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageNumber() {
         return (Integer) getVariableValue(JRVariable.PAGE_NUMBER);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnNumber() {
         return (Integer) getVariableValue(JRVariable.COLUMN_NUMBER);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getReportRowNumber() {
         return (Integer) getVariableValue(JRVariable.REPORT_COUNT);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageRowNumber() {
         return (Integer) getVariableValue(JRVariable.PAGE_COUNT);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnRowNumber() {
         return (Integer) getVariableValue(JRVariable.COLUMN_COUNT);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getCrosstabRowNumber() {
         CrosstabRowCounter counter = (CrosstabRowCounter) getValue(CROSSTAB_ROW_COUNTER);
@@ -186,9 +166,7 @@ public class JasperReportParameters implements ReportParameters {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getGroupCount(String groupName) {
         return (Integer) getVariableValue(groupName + "_COUNT");
@@ -196,9 +174,7 @@ public class JasperReportParameters implements ReportParameters {
 
     // parameter
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getParameterValue(String name) {
@@ -209,41 +185,31 @@ public class JasperReportParameters implements ReportParameters {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Connection getConnection() {
         return (Connection) getParameterValue(JRParameter.REPORT_CONNECTION);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Locale getLocale() {
         return (Locale) getParameterValue(JRParameter.REPORT_LOCALE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIScriptlet getScriptlet(String name) {
         return ((CustomScriptlet) getParameterValue(name + JRScriptlet.SCRIPTLET_PARAMETER_NAME_SUFFIX)).getScriptlet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMessage(String key) {
         return ((ResourceBundle) getParameterValue(JRParameter.REPORT_RESOURCE_BUNDLE)).getString(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMessage(String key, Object[] arguments) {
         String message = getMessage(key);
@@ -274,25 +240,19 @@ public class JasperReportParameters implements ReportParameters {
         return jasperScriptlet.getSystemValue(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ReportParameters getMasterParameters() {
         return (ReportParameters) getParameterValue(MASTER_REPORT_PARAMETERS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSubreportWidth() {
         return jasperScriptlet.getSubreportWidth();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptlet.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptlet.java
@@ -181,18 +181,14 @@ public class JasperScriptlet extends JRDefaultScriptlet {
         return getCustomValues().getSubreportWidth();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setData(Map<String, JRFillParameter> parsm, Map<String, JRFillField> fldsm, Map<String, JRFillVariable> varsm, JRFillGroup[] grps) {
         super.setData(parsm, fldsm, varsm, grps);
         reportParameters = new JasperReportParameters(this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterReportInit() throws JRScriptletException {
         super.afterReportInit();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
@@ -25,21 +25,22 @@ package net.sf.dynamicreports.jasper.base;
  */
 public interface JasperScriptletManager {
 
-  /** Property key used for selecting thread safe implementation. */
-  public static final String USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY =
-      "net.sf.dynamicreports.useThreadSafeScriptletManager";
+    /**
+     * Property key used for selecting thread safe implementation.
+     */
+    public static final String USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY = "net.sf.dynamicreports.useThreadSafeScriptletManager";
 
-  /**
-   * Setter for the {@link JasperScriptlet} instance.
-   * 
-   * @param jasperScriptlet the {@link JasperScriptlet} instance to set
-   */
-  void setJasperScriptlet(JasperScriptlet jasperScriptlet);
+    /**
+     * Getter for the {@link JasperScriptlet} instance.
+     *
+     * @return the set {@link JasperScriptlet} instance
+     */
+    JasperScriptlet getJasperScriptlet();
 
-  /**
-   * Getter for the {@link JasperScriptlet} instance.
-   * 
-   * @return the set {@link JasperScriptlet} instance
-   */
-  JasperScriptlet getJasperScriptlet();
+    /**
+     * Setter for the {@link JasperScriptlet} instance.
+     *
+     * @param jasperScriptlet the {@link JasperScriptlet} instance to set
+     */
+    void setJasperScriptlet(JasperScriptlet jasperScriptlet);
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperScriptletManager.java
@@ -21,7 +21,10 @@
 package net.sf.dynamicreports.jasper.base;
 
 /**
- * Interface for managers of {@link JasperScriptlet} used in {@link JasperCustomValues}.
+ * Interface for managers of {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} used in {@link net.sf.dynamicreports.jasper.base.JasperCustomValues}.
+ *
+ * @author edwin.njeru
+ * @version 6.0.1-SNAPSHOT
  */
 public interface JasperScriptletManager {
 
@@ -31,16 +34,16 @@ public interface JasperScriptletManager {
     public static final String USE_THREAD_SAFE_SCRIPLET_MANAGER_PROPERTY_KEY = "net.sf.dynamicreports.useThreadSafeScriptletManager";
 
     /**
-     * Getter for the {@link JasperScriptlet} instance.
+     * Getter for the {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} instance.
      *
-     * @return the set {@link JasperScriptlet} instance
+     * @return the set {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} instance
      */
     JasperScriptlet getJasperScriptlet();
 
     /**
-     * Setter for the {@link JasperScriptlet} instance.
+     * Setter for the {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} instance.
      *
-     * @param jasperScriptlet the {@link JasperScriptlet} instance to set
+     * @param jasperScriptlet the {@link net.sf.dynamicreports.jasper.base.JasperScriptlet} instance to set
      */
     void setJasperScriptlet(JasperScriptlet jasperScriptlet);
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperSystemFontExtensionsRegistryFactory.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperSystemFontExtensionsRegistryFactory.java
@@ -50,9 +50,7 @@ public class JasperSystemFontExtensionsRegistryFactory implements ExtensionsRegi
      */
     public static final String PROPERTY_SYSTEM_FONT_FAMILIES_REGISTRY_FACTORY = DefaultExtensionsRegistry.PROPERTY_REGISTRY_FACTORY_PREFIX + "system.font.families";
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ExtensionsRegistry createRegistry(String registryId, JRPropertiesMap properties) {
         List<PropertySuffix> fontFamiliesProperties = JRPropertiesUtil.getProperties(properties, SYSTEM_FONT_FAMILIES_PROPERTY_PREFIX);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperSystemFontExtensionsRegistryFactory.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperSystemFontExtensionsRegistryFactory.java
@@ -44,11 +44,11 @@ public class JasperSystemFontExtensionsRegistryFactory implements ExtensionsRegi
     /**
      * Constant <code>SYSTEM_FONT_FAMILIES_PROPERTY_PREFIX="DefaultExtensionsRegistry.PROPERTY_REGI"{trunked}</code>
      */
-    public final static String SYSTEM_FONT_FAMILIES_PROPERTY_PREFIX = DefaultExtensionsRegistry.PROPERTY_REGISTRY_PREFIX + "system.font.families.";
+    public static final String SYSTEM_FONT_FAMILIES_PROPERTY_PREFIX = DefaultExtensionsRegistry.PROPERTY_REGISTRY_PREFIX + "system.font.families.";
     /**
      * Constant <code>PROPERTY_SYSTEM_FONT_FAMILIES_REGISTRY_FACTORY="DefaultExtensionsRegistry.PROPERTY_REGI"{trunked}</code>
      */
-    public final static String PROPERTY_SYSTEM_FONT_FAMILIES_REGISTRY_FACTORY = DefaultExtensionsRegistry.PROPERTY_REGISTRY_FACTORY_PREFIX + "system.font.families";
+    public static final String PROPERTY_SYSTEM_FONT_FAMILIES_REGISTRY_FACTORY = DefaultExtensionsRegistry.PROPERTY_REGISTRY_FACTORY_PREFIX + "system.font.families";
 
     /**
      * {@inheritDoc}

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperTemplateStyleLoader.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/JasperTemplateStyleLoader.java
@@ -227,7 +227,7 @@ public class JasperTemplateStyleLoader {
         font.setFontName(jrStyle.getOwnFontName());
         font.setBold(jrStyle.isOwnBold());
         font.setItalic(jrStyle.isOwnItalic());
-        font.setFontSize(jrStyle.getOwnFontsize() == null? null: jrStyle.getOwnFontsize().intValue());
+        font.setFontSize(jrStyle.getOwnFontsize() == null ? null : jrStyle.getOwnFontsize().intValue());
         font.setStrikeThrough(jrStyle.isOwnStrikeThrough());
         font.setUnderline(jrStyle.isOwnUnderline());
         font.setPdfFontName(jrStyle.getOwnPdfFontName());

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/StartPageNumberScriptlet.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/StartPageNumberScriptlet.java
@@ -42,9 +42,7 @@ public class StartPageNumberScriptlet extends JRDefaultScriptlet {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterReportInit() throws JRScriptletException {
         super.afterReportInit();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
@@ -21,23 +21,22 @@
 package net.sf.dynamicreports.jasper.base;
 
 /**
- * Thread safe implementation of {@link JasperScriptletManager} used for filling
- * cached reports concurrently. Note: use of this class can lead to memory leaks
- * if the threads starting the report fill are not terminated properly.
+ * Thread safe implementation of {@link JasperScriptletManager} used for filling cached reports concurrently. Note: use of this class can lead to memory leaks if the threads starting the report fill
+ * are not terminated properly.
  */
 public class ThreadSafeJasperScriptletManager implements JasperScriptletManager {
 
-  private ThreadLocal<JasperScriptlet> threadLocalScriptlet = new ThreadLocal<>();
-  
-  @Override
-  public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
-    threadLocalScriptlet.set(jasperScriptlet);
+    private ThreadLocal<JasperScriptlet> threadLocalScriptlet = new ThreadLocal<>();
 
-  }
+    @Override
+    public JasperScriptlet getJasperScriptlet() {
+        return threadLocalScriptlet.get();
+    }
 
-  @Override
-  public JasperScriptlet getJasperScriptlet() {
-    return threadLocalScriptlet.get();
-  }
+    @Override
+    public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
+        threadLocalScriptlet.set(jasperScriptlet);
+
+    }
 
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/ThreadSafeJasperScriptletManager.java
@@ -21,18 +21,23 @@
 package net.sf.dynamicreports.jasper.base;
 
 /**
- * Thread safe implementation of {@link JasperScriptletManager} used for filling cached reports concurrently. Note: use of this class can lead to memory leaks if the threads starting the report fill
+ * Thread safe implementation of {@link net.sf.dynamicreports.jasper.base.JasperScriptletManager} used for filling cached reports concurrently. Note: use of this class can lead to memory leaks if the threads starting the report fill
  * are not terminated properly.
+ *
+ * @author edwin.njeru
+ * @version 6.0.1-SNAPSHOT
  */
 public class ThreadSafeJasperScriptletManager implements JasperScriptletManager {
 
     private ThreadLocal<JasperScriptlet> threadLocalScriptlet = new ThreadLocal<>();
 
+    /** {@inheritDoc} */
     @Override
     public JasperScriptlet getJasperScriptlet() {
         return threadLocalScriptlet.get();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setJasperScriptlet(JasperScriptlet jasperScriptlet) {
         threadLocalScriptlet.set(jasperScriptlet);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/AbstractJasperExcelExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/AbstractJasperExcelExporter.java
@@ -86,9 +86,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetNames = new ArrayList<String>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getOnePagePerSheet() {
         return onePagePerSheet;
@@ -103,9 +101,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.onePagePerSheet = onePagePerSheet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRemoveEmptySpaceBetweenRows() {
         return removeEmptySpaceBetweenRows;
@@ -120,9 +116,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.removeEmptySpaceBetweenRows = removeEmptySpaceBetweenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRemoveEmptySpaceBetweenColumns() {
         return removeEmptySpaceBetweenColumns;
@@ -137,9 +131,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.removeEmptySpaceBetweenColumns = removeEmptySpaceBetweenColumns;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWhitePageBackground() {
         return whitePageBackground;
@@ -154,9 +146,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.whitePageBackground = whitePageBackground;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDetectCellType() {
         return detectCellType;
@@ -171,9 +161,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.detectCellType = detectCellType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<String> getSheetNames() {
         return sheetNames;
@@ -197,9 +185,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetNames.add(sheetName);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFontSizeFixEnabled() {
         return fontSizeFixEnabled;
@@ -214,9 +200,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.fontSizeFixEnabled = fontSizeFixEnabled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getImageBorderFixEnabled() {
         return imageBorderFixEnabled;
@@ -231,9 +215,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.imageBorderFixEnabled = imageBorderFixEnabled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMaxRowsPerSheet() {
         return maxRowsPerSheet;
@@ -248,9 +230,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.maxRowsPerSheet = maxRowsPerSheet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreGraphics() {
         return ignoreGraphics;
@@ -265,9 +245,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignoreGraphics = ignoreGraphics;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCollapseRowSpan() {
         return collapseRowSpan;
@@ -282,9 +260,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.collapseRowSpan = collapseRowSpan;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreCellBorder() {
         return ignoreCellBorder;
@@ -299,9 +275,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignoreCellBorder = ignoreCellBorder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreCellBackground() {
         return ignoreCellBackground;
@@ -316,9 +290,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignoreCellBackground = ignoreCellBackground;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPassword() {
         return password;
@@ -333,9 +305,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.password = password;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePageMargins() {
         return ignorePageMargins;
@@ -350,9 +320,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignorePageMargins = ignorePageMargins;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWrapText() {
         return wrapText;
@@ -367,9 +335,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.wrapText = wrapText;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCellLocked() {
         return cellLocked;
@@ -384,9 +350,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.cellLocked = cellLocked;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCellHidden() {
         return cellHidden;
@@ -401,9 +365,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.cellHidden = cellHidden;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetHeaderLeft() {
         return sheetHeaderLeft;
@@ -418,9 +380,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetHeaderLeft = sheetHeaderLeft;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetHeaderCenter() {
         return sheetHeaderCenter;
@@ -435,9 +395,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetHeaderCenter = sheetHeaderCenter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetHeaderRight() {
         return sheetHeaderRight;
@@ -452,9 +410,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetHeaderRight = sheetHeaderRight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetFooterLeft() {
         return sheetFooterLeft;
@@ -469,9 +425,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetFooterLeft = sheetFooterLeft;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetFooterCenter() {
         return sheetFooterCenter;
@@ -486,9 +440,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetFooterCenter = sheetFooterCenter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getSheetFooterRight() {
         return sheetFooterRight;
@@ -503,9 +455,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetFooterRight = sheetFooterRight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, String> getFormatPatternsMap() {
         return formatPatternsMap;
@@ -520,9 +470,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.formatPatternsMap = formatPatternsMap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;
@@ -537,9 +485,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignoreHyperLink = ignoreHyperLink;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreAnchors() {
         return ignoreAnchors;
@@ -554,9 +500,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.ignoreAnchors = ignoreAnchors;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFitWidth() {
         return fitWidth;
@@ -571,9 +515,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.fitWidth = fitWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFitHeight() {
         return fitHeight;
@@ -588,9 +530,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.fitHeight = fitHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageScale() {
         return pageScale;
@@ -605,9 +545,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.pageScale = pageScale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getSheetDirection() {
         return sheetDirection;
@@ -622,9 +560,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.sheetDirection = sheetDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getColumnWidthRatio() {
         return columnWidthRatio;
@@ -639,9 +575,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.columnWidthRatio = columnWidthRatio;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUseTimeZone() {
         return useTimeZone;
@@ -656,9 +590,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.useTimeZone = useTimeZone;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFirstPageNumber() {
         return firstPageNumber;
@@ -673,9 +605,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.firstPageNumber = firstPageNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowGridLines() {
         return showGridLines;
@@ -690,9 +620,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.showGridLines = showGridLines;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageAnchorType getImageAnchorType() {
         return imageAnchorType;
@@ -707,9 +635,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.imageAnchorType = imageAnchorType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCreateCustomPalette() {
         return createCustomPalette;
@@ -724,9 +650,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.createCustomPalette = createCustomPalette;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getWorkbookTemplate() {
         return workbookTemplate;
@@ -741,9 +665,7 @@ public abstract class AbstractJasperExcelExporter extends AbstractJasperExporter
         this.workbookTemplate = workbookTemplate;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getKeepWorkbookTemplateSheets() {
         return keepWorkbookTemplateSheets;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/AbstractJasperExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/AbstractJasperExporter.java
@@ -50,9 +50,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
     private Integer offsetX;
     private Integer offsetY;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Writer getOutputWriter() {
         return outputWriter;
@@ -68,9 +66,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.outputWriter = outputWriter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OutputStream getOutputStream() {
         return outputStream;
@@ -86,9 +82,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.outputStream = outputStream;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public File getOutputFile() {
         return outputFile;
@@ -104,9 +98,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.outputFile = outputFile;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getOutputFileName() {
         return outputFileName;
@@ -122,9 +114,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.outputFileName = outputFileName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageIndex() {
         return pageIndex;
@@ -139,9 +129,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.pageIndex = pageIndex;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getStartPageIndex() {
         return startPageIndex;
@@ -156,9 +144,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.startPageIndex = startPageIndex;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getEndPageIndex() {
         return endPageIndex;
@@ -173,9 +159,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.endPageIndex = endPageIndex;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getCharacterEncoding() {
         return characterEncoding;
@@ -190,9 +174,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.characterEncoding = characterEncoding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getOffsetX() {
         return offsetX;
@@ -207,9 +189,7 @@ public abstract class AbstractJasperExporter implements JasperIExporter {
         this.offsetX = offsetX;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getOffsetY() {
         return offsetY;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperCsvExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperCsvExporter.java
@@ -36,9 +36,7 @@ public class JasperCsvExporter extends AbstractJasperExporter implements JasperI
     private String fieldDelimiter;
     private String recordDelimiter;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getFieldDelimiter() {
         return fieldDelimiter;
@@ -53,9 +51,7 @@ public class JasperCsvExporter extends AbstractJasperExporter implements JasperI
         this.fieldDelimiter = fieldDelimiter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getRecordDelimiter() {
         return recordDelimiter;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperDocxExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperDocxExporter.java
@@ -37,9 +37,7 @@ public class JasperDocxExporter extends AbstractJasperExporter implements Jasper
     private Boolean flexibleRowHeight;
     private Boolean ignoreHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFramesAsNestedTables() {
         return framesAsNestedTables;
@@ -54,9 +52,7 @@ public class JasperDocxExporter extends AbstractJasperExporter implements Jasper
         this.framesAsNestedTables = framesAsNestedTables;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFlexibleRowHeight() {
         return flexibleRowHeight;
@@ -71,9 +67,7 @@ public class JasperDocxExporter extends AbstractJasperExporter implements Jasper
         this.flexibleRowHeight = flexibleRowHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperHtmlExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperHtmlExporter.java
@@ -53,9 +53,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
     private Boolean ignoreHyperLink;
     private Boolean flushOutput;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getOutputImagesToDir() {
         return outputImagesToDir;
@@ -70,9 +68,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.outputImagesToDir = outputImagesToDir;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getImagesDirName() {
         return imagesDirName;
@@ -87,9 +83,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.imagesDirName = imagesDirName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getImagesURI() {
         return imagesURI;
@@ -104,9 +98,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.imagesURI = imagesURI;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getHtmlHeader() {
         return htmlHeader;
@@ -121,9 +113,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.htmlHeader = htmlHeader;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getBetweenPagesHtml() {
         return betweenPagesHtml;
@@ -138,9 +128,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.betweenPagesHtml = betweenPagesHtml;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getHtmlFooter() {
         return htmlFooter;
@@ -155,9 +143,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.htmlFooter = htmlFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRemoveEmptySpaceBetweenRows() {
         return removeEmptySpaceBetweenRows;
@@ -172,9 +158,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.removeEmptySpaceBetweenRows = removeEmptySpaceBetweenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWhitePageBackground() {
         return whitePageBackground;
@@ -189,9 +173,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.whitePageBackground = whitePageBackground;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUsingImagesToAlign() {
         return usingImagesToAlign;
@@ -206,9 +188,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.usingImagesToAlign = usingImagesToAlign;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWrapBreakWord() {
         return wrapBreakWord;
@@ -223,9 +203,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.wrapBreakWord = wrapBreakWord;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SizeUnit getSizeUnit() {
         return sizeUnit;
@@ -240,9 +218,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.sizeUnit = sizeUnit;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFramesAsNestedTables() {
         return framesAsNestedTables;
@@ -257,9 +233,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.framesAsNestedTables = framesAsNestedTables;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePageMargins() {
         return ignorePageMargins;
@@ -274,9 +248,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.ignorePageMargins = ignorePageMargins;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getBorderCollapse() {
         return borderCollapse;
@@ -291,9 +263,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.borderCollapse = borderCollapse;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getAccessibleHtml() {
         return accessibleHtml;
@@ -308,9 +278,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.accessibleHtml = accessibleHtml;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getZoomRatio() {
         return zoomRatio;
@@ -325,9 +293,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.zoomRatio = zoomRatio;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;
@@ -342,9 +308,7 @@ public class JasperHtmlExporter extends AbstractJasperExporter implements Jasper
         this.ignoreHyperLink = ignoreHyperLink;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFlushOutput() {
         return flushOutput;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperImageExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperImageExporter.java
@@ -39,9 +39,7 @@ public class JasperImageExporter extends AbstractJasperExporter implements Jaspe
     private ImageType imageType;
     private Float zoomRatio;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageGap() {
         return pageGap;
@@ -56,9 +54,7 @@ public class JasperImageExporter extends AbstractJasperExporter implements Jaspe
         this.pageGap = pageGap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageType getImageType() {
         return imageType;
@@ -74,9 +70,7 @@ public class JasperImageExporter extends AbstractJasperExporter implements Jaspe
         this.imageType = imageType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getZoomRatio() {
         return zoomRatio;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperOdsExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperOdsExporter.java
@@ -35,9 +35,7 @@ public class JasperOdsExporter extends AbstractJasperExcelExporter implements Ja
 
     private Boolean flexibleRowHeight;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFlexibleRowHeight() {
         return flexibleRowHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperOdtExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperOdtExporter.java
@@ -36,9 +36,7 @@ public class JasperOdtExporter extends AbstractJasperExporter implements JasperI
     private Boolean flexibleRowHeight;
     private Boolean ignoreHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFlexibleRowHeight() {
         return flexibleRowHeight;
@@ -53,9 +51,7 @@ public class JasperOdtExporter extends AbstractJasperExporter implements JasperI
         this.flexibleRowHeight = flexibleRowHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperPdfExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperPdfExporter.java
@@ -75,9 +75,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         permissions = new ArrayList<PdfPermission>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCreatingBatchModeBookmarks() {
         return creatingBatchModeBookmarks;
@@ -92,9 +90,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.creatingBatchModeBookmarks = creatingBatchModeBookmarks;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCompressed() {
         return compressed;
@@ -109,9 +105,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.compressed = compressed;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getEncrypted() {
         return encrypted;
@@ -126,9 +120,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.encrypted = encrypted;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getBitKey128() {
         return bitKey128;
@@ -143,9 +135,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.bitKey128 = bitKey128;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getUserPassword() {
         return userPassword;
@@ -160,9 +150,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.userPassword = userPassword;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getOwnerPassword() {
         return ownerPassword;
@@ -177,9 +165,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.ownerPassword = ownerPassword;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<PdfPermission> getPermissions() {
         return permissions;
@@ -203,9 +189,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.permissions.add(permission);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PdfVersion getPdfVersion() {
         return pdfVersion;
@@ -220,9 +204,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.pdfVersion = pdfVersion;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMetadataTitle() {
         return metadataTitle;
@@ -237,9 +219,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.metadataTitle = metadataTitle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMetadataAuthor() {
         return metadataAuthor;
@@ -254,9 +234,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.metadataAuthor = metadataAuthor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMetadataSubject() {
         return metadataSubject;
@@ -271,9 +249,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.metadataSubject = metadataSubject;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMetadataKeyWords() {
         return metadataKeyWords;
@@ -288,9 +264,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.metadataKeyWords = metadataKeyWords;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMetadataCreator() {
         return metadataCreator;
@@ -305,9 +279,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.metadataCreator = metadataCreator;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getForceSvgShapes() {
         return forceSvgShapes;
@@ -322,9 +294,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.forceSvgShapes = forceSvgShapes;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPdfJavaScript() {
         return pdfJavaScript;
@@ -339,9 +309,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.pdfJavaScript = pdfJavaScript;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTagged() {
         return tagged;
@@ -356,9 +324,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.tagged = tagged;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTagLanguage() {
         return tagLanguage;
@@ -373,9 +339,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.tagLanguage = tagLanguage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCollapseMissingBookmarkLevels() {
         return collapseMissingBookmarkLevels;
@@ -390,9 +354,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.collapseMissingBookmarkLevels = collapseMissingBookmarkLevels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSizePageToContent() {
         return sizePageToContent;
@@ -407,9 +369,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.sizePageToContent = sizePageToContent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;
@@ -424,9 +384,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.ignoreHyperLink = ignoreHyperLink;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getForceLineBreakPolicy() {
         return forceLineBreakPolicy;
@@ -441,9 +399,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.forceLineBreakPolicy = forceLineBreakPolicy;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PdfPrintScaling getPrintScaling() {
         return printScaling;
@@ -458,9 +414,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.printScaling = printScaling;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PdfaConformance getPdfaConformance() {
         return pdfaConformance;
@@ -475,9 +429,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.pdfaConformance = pdfaConformance;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getIccProfilePath() {
         return iccProfilePath;
@@ -492,9 +444,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.iccProfilePath = iccProfilePath;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getAllowedPermissionsHint() {
         return allowedPermissionsHint;
@@ -509,9 +459,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.allowedPermissionsHint = allowedPermissionsHint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getDeniedPermissionsHint() {
         return deniedPermissionsHint;
@@ -526,9 +474,7 @@ public class JasperPdfExporter extends AbstractJasperExporter implements JasperI
         this.deniedPermissionsHint = deniedPermissionsHint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayMetadataTitle() {
         return displayMetadataTitle;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperPptxExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperPptxExporter.java
@@ -35,9 +35,7 @@ public class JasperPptxExporter extends AbstractJasperExporter implements Jasper
 
     private Boolean ignoreHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperRtfExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperRtfExporter.java
@@ -35,9 +35,7 @@ public class JasperRtfExporter extends AbstractJasperExporter implements JasperI
 
     private Boolean ignoreHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreHyperLink() {
         return ignoreHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperTextExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperTextExporter.java
@@ -41,9 +41,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
     private String lineSeparator;
     private Boolean trimLineRight;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getCharacterWidth() {
         return characterWidth;
@@ -58,9 +56,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.characterWidth = characterWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getCharacterHeight() {
         return characterHeight;
@@ -75,9 +71,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.characterHeight = characterHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageWidthInChars() {
         return pageWidthInChars;
@@ -92,9 +86,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.pageWidthInChars = pageWidthInChars;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageHeightInChars() {
         return pageHeightInChars;
@@ -109,9 +101,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.pageHeightInChars = pageHeightInChars;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPageSeparator() {
         return pageSeparator;
@@ -126,9 +116,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.pageSeparator = pageSeparator;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLineSeparator() {
         return lineSeparator;
@@ -143,9 +131,7 @@ public class JasperTextExporter extends AbstractJasperExporter implements Jasper
         this.lineSeparator = lineSeparator;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTrimLineRight() {
         return trimLineRight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperXlsxExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperXlsxExporter.java
@@ -35,9 +35,7 @@ public class JasperXlsxExporter extends AbstractJasperExcelExporter implements J
 
     private String macroTemplate;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getMacroTemplate() {
         return macroTemplate;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperXmlExporter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/export/JasperXmlExporter.java
@@ -35,9 +35,7 @@ public class JasperXmlExporter extends AbstractJasperExporter implements JasperI
 
     private Boolean embeddingImages;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getEmbeddingImages() {
         return embeddingImages;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/AbstractPrintListHandler.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/AbstractPrintListHandler.java
@@ -43,9 +43,7 @@ public abstract class AbstractPrintListHandler implements JasperReportHandler {
         pageNumber = 1;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void concatenate(JasperReportBuilder... jasperReportBuilders) {
         for (JasperReportBuilder jasperReportBuilder : jasperReportBuilders) {
@@ -71,9 +69,7 @@ public abstract class AbstractPrintListHandler implements JasperReportHandler {
      */
     protected abstract void add(JasperPrint jasperPrint);
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setContinuousPageNumbering(boolean continuousPageNumbering) {
         this.continuousPageNumbering = continuousPageNumbering;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperPrintListFileHandler.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperPrintListFileHandler.java
@@ -74,9 +74,7 @@ public class JasperPrintListFileHandler extends AbstractPrintListHandler {
         tempFiles = new ArrayList<File>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void add(JasperPrint jasperPrint) {
         try {
@@ -90,17 +88,13 @@ public class JasperPrintListFileHandler extends AbstractPrintListHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<JasperPrint> getPrintList() {
         return printList;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void finalize() throws Throwable {
         for (File tempFile : tempFiles) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperPrintListHandler.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperPrintListHandler.java
@@ -42,17 +42,13 @@ public class JasperPrintListHandler extends AbstractPrintListHandler {
         printList = new ArrayList<JasperPrint>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void add(JasperPrint jasperPrint) {
         printList.add(jasperPrint);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<JasperPrint> getPrintList() {
         return printList;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperReportBuilderHandler.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/reporthandler/JasperReportBuilderHandler.java
@@ -47,9 +47,7 @@ public class JasperReportBuilderHandler implements JasperReportHandler {
         continuousPageNumbering = false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void concatenate(JasperReportBuilder... jasperReportBuilders) {
         for (JasperReportBuilder jasperReportBuilder : jasperReportBuilders) {
@@ -57,17 +55,13 @@ public class JasperReportBuilderHandler implements JasperReportHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setContinuousPageNumbering(boolean continuousPageNumbering) {
         this.continuousPageNumbering = continuousPageNumbering;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<JasperPrint> getPrintList() throws DRException {
         List<JasperPrint> printList = new ArrayList<JasperPrint>();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/tableofcontents/JasperTocReport.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/tableofcontents/JasperTocReport.java
@@ -67,7 +67,7 @@ public class JasperTocReport {
      * @param jasperPrint        a {@link net.sf.jasperreports.engine.JasperPrint} object.
      * @param parameters         a {@link java.util.Map} object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
-     * @throws net.sf.jasperreports.engine.JRException            if any.
+     * @throws net.sf.jasperreports.engine.JRException if any.
      */
     public static void createTocReport(JasperReportDesign jasperReportDesign, JasperPrint jasperPrint, Map<String, Object> parameters) throws DRException, JRException {
         JasperCustomValues customValues = jasperReportDesign.getCustomValues();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/templatedesign/JasperEmptyTemplateDesign.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/templatedesign/JasperEmptyTemplateDesign.java
@@ -35,9 +35,7 @@ import net.sf.jasperreports.engine.design.JasperDesign;
 public class JasperEmptyTemplateDesign extends AbstractTemplateDesign<JasperDesign> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperDesign getDesign() throws DRException {
         JasperDesign design = new JasperDesign();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/templatedesign/JasperTemplateDesign.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/base/templatedesign/JasperTemplateDesign.java
@@ -153,218 +153,164 @@ public class JasperTemplateDesign implements DRITemplateDesign<JasperDesign> {
         margin.setRight(jasperDesign.getRightMargin());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getReportName() {
         return jasperDesign.getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIField<?>> getFields() {
         return fields;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isDefinedParameter(String name) {
         JRParameter parameter = jasperDesign.getParametersMap().get(name);
         return parameter != null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getResourceBundleName() {
         return jasperDesign.getResourceBundle();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePagination() {
         return jasperDesign.isIgnorePagination();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenNoDataType getWhenNoDataType() {
         return ConstantTransform.whenNoDataType(jasperDesign.getWhenNoDataTypeValue());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenResourceMissingType getWhenResourceMissingType() {
         return ConstantTransform.whenResourceMissingType(jasperDesign.getWhenResourceMissingTypeValue());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleOnANewPage() {
         return jasperDesign.isTitleNewPage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryOnANewPage() {
         return jasperDesign.isSummaryNewPage();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryWithPageHeaderAndFooter() {
         return jasperDesign.isSummaryWithPageHeaderAndFooter();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFloatColumnFooter() {
         return jasperDesign.isFloatColumnFooter();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageWidth() {
         return jasperDesign.getPageWidth();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageHeight() {
         return jasperDesign.getPageHeight();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageOrientation getPageOrientation() {
         return ConstantTransform.pageOrientation(jasperDesign.getOrientationValue());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIMargin getPageMargin() {
         return margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnsPerPage() {
         return jasperDesign.getColumnCount();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnSpace() {
         return jasperDesign.getColumnSpacing();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnWidth() {
         return jasperDesign.getColumnWidth();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getTitleComponentsCount() {
         return getBandComponentsCount(jasperDesign.getTitle());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageHeaderComponentsCount() {
         return getBandComponentsCount(jasperDesign.getPageHeader());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageFooterComponentsCount() {
         return getBandComponentsCount(jasperDesign.getPageFooter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnHeaderComponentsCount() {
         return getBandComponentsCount(jasperDesign.getColumnHeader());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnFooterComponentsCount() {
         return getBandComponentsCount(jasperDesign.getColumnFooter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getLastPageFooterComponentsCount() {
         return getBandComponentsCount(jasperDesign.getLastPageFooter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getSummaryComponentsCount() {
         return getBandComponentsCount(jasperDesign.getSummary());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getNoDataComponentsCount() {
         return getBandComponentsCount(jasperDesign.getNoData());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getBackgroundComponentsCount() {
         return getBandComponentsCount(jasperDesign.getBackground());
@@ -377,9 +323,7 @@ public class JasperTemplateDesign implements DRITemplateDesign<JasperDesign> {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperDesign getDesign() throws DRException {
         try {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/builder/JasperReportBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/builder/JasperReportBuilder.java
@@ -249,9 +249,7 @@ public class JasperReportBuilder extends ReportBuilder<JasperReportBuilder> {
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperReportBuilder setParameter(String name, Object value) {
         super.setParameter(name, value);
@@ -260,9 +258,7 @@ public class JasperReportBuilder extends ReportBuilder<JasperReportBuilder> {
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperReportBuilder setParameters(Map<String, Object> parameters) {
         super.setParameters(parameters);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/DatasetExpressionTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/DatasetExpressionTransform.java
@@ -62,89 +62,67 @@ public class DatasetExpressionTransform extends AbstractExpressionTransform {
         this.customValues = customValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JasperCustomValues getCustomValues() {
         return customValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignField> getFields() {
         return dataset.getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignVariable> getVariables() {
         return dataset.getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSystemExpression> getSystemExpressions() {
         return dataset.getSystemExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignJasperExpression> getJasperExpressions() {
         return dataset.getJasperExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSimpleExpression> getSimpleExpressions() {
         return dataset.getSimpleExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignComplexExpression> getComplexExpressions() {
         return dataset.getComplexExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSort> getSorts() {
         return dataset.getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addField(JRDesignField field) throws JRException {
         jrDataset.addField(field);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addVariable(JRDesignVariable variable) throws JRException {
         jrDataset.addVariable(variable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addSort(JRDesignSortField sort) throws JRException {
         jrDataset.addSortField(sort);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/JasperTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/JasperTransform.java
@@ -94,57 +94,43 @@ public class JasperTransform implements JasperTransformAccessor {
         reportTransform.addDependencies();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ReportTransform getReportTransform() {
         return reportTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ChartTransform getChartTransform() {
         return chartTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeTransform getBarcodeTransform() {
         return barcodeTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabTransform getCrosstabTransform() {
         return crosstabTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentTransform getComponentTransform() {
         return componentTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void transformToMainDataset() {
         transformToDataset(null);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void transformToDataset(DRIDesignDataset dataset) {
         if (dataset != null) {
@@ -154,17 +140,13 @@ public class JasperTransform implements JasperTransformAccessor {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public AbstractExpressionTransform getExpressionTransform() {
         return expressionTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public AbstractExpressionTransform getExpressionTransform(DRIDesignDataset dataset) {
         if (dataset == null) {
@@ -174,81 +156,61 @@ public class JasperTransform implements JasperTransformAccessor {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupTransform getGroupTransform() {
         return groupTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public StyleTransform getStyleTransform() {
         return styleTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DatasetTransform getDatasetTransform() {
         return datasetTransform;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDesignReport getReport() {
         return report;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperCustomValues getCustomValues() {
         return jasperReportDesign.getCustomValues();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JasperDesign getDesign() {
         return jasperReportDesign.getDesign();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, Object> getParameters() {
         return jasperReportDesign.getParameters();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, Object> getParameterValues() {
         return report.getParameterValues();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getStartPageNumber() {
         return jasperReportDesign.getStartPageNumber();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ReportParameters getMasterReportParameters() {
         return jasperReportDesign.getMasterReportParameters();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/MainDatasetExpressionTransform.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/MainDatasetExpressionTransform.java
@@ -56,97 +56,73 @@ public class MainDatasetExpressionTransform extends AbstractExpressionTransform 
         this.accessor = accessor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JasperCustomValues getCustomValues() {
         return accessor.getCustomValues();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JRGroup getGroup(DRIDesignGroup group) {
         return accessor.getGroupTransform().getGroup(group);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignField> getFields() {
         return accessor.getReport().getFields();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignVariable> getVariables() {
         return accessor.getReport().getVariables();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSystemExpression> getSystemExpressions() {
         return accessor.getReport().getSystemExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignJasperExpression> getJasperExpressions() {
         return accessor.getReport().getJasperExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSimpleExpression> getSimpleExpressions() {
         return accessor.getReport().getSimpleExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignComplexExpression> getComplexExpressions() {
         return accessor.getReport().getComplexExpressions();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Collection<DRIDesignSort> getSorts() {
         return accessor.getReport().getSorts();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addField(JRDesignField field) throws JRException {
         accessor.getDesign().addField(field);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addVariable(JRDesignVariable variable) throws JRException {
         accessor.getDesign().addVariable(variable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void addSort(JRDesignSortField sort) throws JRException {
         accessor.getDesign().addSortField(sort);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/CrosstabParametersExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/CrosstabParametersExpression.java
@@ -51,9 +51,7 @@ public class CrosstabParametersExpression extends AbstractDesignSimpleExpression
         this.parameters = parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(ReportParameters reportParameters) {
         Map<String, Object> parameters = new HashMap<String, Object>(this.parameters);
@@ -61,9 +59,7 @@ public class CrosstabParametersExpression extends AbstractDesignSimpleExpression
         return parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return Map.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/DatasetParametersExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/DatasetParametersExpression.java
@@ -51,9 +51,7 @@ public class DatasetParametersExpression extends AbstractDesignSimpleExpression 
         this.parameters = parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(ReportParameters reportParameters) {
         Map<String, Object> parameters = new HashMap<String, Object>(this.parameters);
@@ -61,9 +59,7 @@ public class DatasetParametersExpression extends AbstractDesignSimpleExpression 
         return parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return Map.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/JasperSubreportParametersExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/JasperSubreportParametersExpression.java
@@ -53,9 +53,7 @@ public class JasperSubreportParametersExpression extends AbstractDesignComplexEx
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Object evaluate(List<?> values, ReportParameters reportParameters) {
@@ -69,9 +67,7 @@ public class JasperSubreportParametersExpression extends AbstractDesignComplexEx
         return parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return Map.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportExpression.java
@@ -64,6 +64,7 @@ public class SubreportExpression extends AbstractDesignComplexExpression {
      *
      * @param pageWidthExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignExpression} object.
      * @param reportExpression    a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignExpression} object.
+     * @param pageWidthExpression a {@link net.sf.dynamicreports.design.definition.expression.DRIDesignExpression} object.
      * @param pageWidth           a {@link java.lang.Integer} object.
      */
     public SubreportExpression(DRIDesignExpression pageWidthExpression, DRIDesignExpression reportExpression, Integer pageWidth) {
@@ -75,9 +76,7 @@ public class SubreportExpression extends AbstractDesignComplexExpression {
         jasperReports = new HashMap<ReportBuilder<?>, JasperReport>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(List<?> values, ReportParameters reportParameters) {
         reportBuilder = (ReportBuilder<?>) values.get(1);
@@ -124,17 +123,13 @@ public class SubreportExpression extends AbstractDesignComplexExpression {
         return reportBuilder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return JasperReport.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportParametersExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportParametersExpression.java
@@ -57,9 +57,7 @@ public class SubreportParametersExpression extends AbstractDesignComplexExpressi
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Object evaluate(List<?> values, ReportParameters reportParameters) {
@@ -75,9 +73,7 @@ public class SubreportParametersExpression extends AbstractDesignComplexExpressi
         return parameters;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return Map.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportWidthExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/jasper/transformation/expression/SubreportWidthExpression.java
@@ -46,9 +46,7 @@ public class SubreportWidthExpression extends AbstractDesignSimpleExpression {
         this.pageWidth = pageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object evaluate(ReportParameters reportParameters) {
         DRICustomValues customValues = (DRICustomValues) reportParameters.getParameterValue(DRICustomValues.NAME);
@@ -56,9 +54,7 @@ public class SubreportWidthExpression extends AbstractDesignSimpleExpression {
         return pageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<?> getValueClass() {
         return Integer.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/ReportUtils.java
@@ -20,11 +20,11 @@
 
 package net.sf.dynamicreports.report;
 
+import net.sf.dynamicreports.report.constant.Calculation;
+
 import java.lang.reflect.ParameterizedType;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import net.sf.dynamicreports.report.constant.Calculation;
 
 /**
  * <p>
@@ -35,103 +35,101 @@ import net.sf.dynamicreports.report.constant.Calculation;
  * @version $Id: $Id
  */
 public class ReportUtils {
-  private static final Lock LOCK = new ReentrantLock();
-  private static int counter = 0;
+    private static final Lock LOCK = new ReentrantLock();
+    private static int counter;
 
-  /**
-   * <p>
-   * generateUniqueName.
-   * </p>
-   *
-   * @param name a {@link java.lang.String} object.
-   * @return a {@link java.lang.String} object.
-   */
-  public static String generateUniqueName(String name) {
-    try {
-      LOCK.lock();
-      return generateName(name);
-    } finally {
-      LOCK.unlock();
+    /**
+     * <p>
+     * generateUniqueName.
+     * </p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
+    public static String generateUniqueName(String name) {
+        try {
+            LOCK.lock();
+            return generateName(name);
+        } finally {
+            LOCK.unlock();
+        }
     }
-  }
 
-  /**
-   * <p>
-   * getVariableValueClass.
-   * </p>
-   *
-   * @param calculation a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-   * @param valueClass a {@link java.lang.Class} object.
-   * @return a {@link java.lang.Class} object.
-   */
-  public static Class<?> getVariableValueClass(Calculation calculation, Class<?> valueClass) {
-    if (calculation.equals(Calculation.COUNT) || calculation.equals(Calculation.DISTINCT_COUNT)) {
-      return Long.class;
+    /**
+     * <p>
+     * getVariableValueClass.
+     * </p>
+     *
+     * @param calculation a {@link net.sf.dynamicreports.report.constant.Calculation} object.
+     * @param valueClass  a {@link java.lang.Class} object.
+     * @return a {@link java.lang.Class} object.
+     */
+    public static Class<?> getVariableValueClass(Calculation calculation, Class<?> valueClass) {
+        if (calculation.equals(Calculation.COUNT) || calculation.equals(Calculation.DISTINCT_COUNT)) {
+            return Long.class;
+        }
+        if (calculation.equals(Calculation.AVERAGE) || calculation.equals(Calculation.STANDARD_DEVIATION) || calculation.equals(Calculation.VARIANCE)) {
+            return Number.class;
+        }
+        return valueClass;
     }
-    if (calculation.equals(Calculation.AVERAGE)
-        || calculation.equals(Calculation.STANDARD_DEVIATION)
-        || calculation.equals(Calculation.VARIANCE)) {
-      return Number.class;
-    }
-    return valueClass;
-  }
 
-  /**
-   * <p>
-   * getGenericClass.
-   * </p>
-   *
-   * @param object a {@link java.lang.Object} object.
-   * @param index a int.
-   * @return a {@link java.lang.Class} object.
-   */
-  public static Class<?> getGenericClass(Object object, int index) {
-    ParameterizedType genericSuperclass = getParameterizedType(object.getClass());
-    if (genericSuperclass == null) {
-      return String.class;
+    /**
+     * <p>
+     * getGenericClass.
+     * </p>
+     *
+     * @param object a {@link java.lang.Object} object.
+     * @param index  a int.
+     * @return a {@link java.lang.Class} object.
+     */
+    public static Class<?> getGenericClass(Object object, int index) {
+        ParameterizedType genericSuperclass = getParameterizedType(object.getClass());
+        if (genericSuperclass == null) {
+            return String.class;
+        }
+        Class<?> rawType = getRawType(genericSuperclass.getActualTypeArguments()[index]);
+        if (rawType == null) {
+            return String.class;
+        }
+        return rawType;
     }
-    Class<?> rawType = getRawType(genericSuperclass.getActualTypeArguments()[index]);
-    if (rawType == null) {
-      return String.class;
-    }
-    return rawType;
-  }
 
-  /**
-   * Setter for testing purposes only.
-   * 
-   * @param counter the counter value
-   */
-  static void setCounter(int counter) {
-    ReportUtils.counter = counter;
-  }
+    /**
+     * Setter for testing purposes only.
+     *
+     * @param counter the counter value
+     */
+    static void setCounter(int counter) {
+        ReportUtils.counter = counter;
+    }
 
-  private static ParameterizedType getParameterizedType(Class<?> classs) {
-    if (classs == null) {
-      return null;
+    private static ParameterizedType getParameterizedType(Class<?> classs) {
+        if (classs == null) {
+            return null;
+        }
+        if (classs.getGenericSuperclass() instanceof ParameterizedType) {
+            return (ParameterizedType) classs.getGenericSuperclass();
+        }
+        return getParameterizedType((Class<?>) classs.getGenericSuperclass());
     }
-    if (classs.getGenericSuperclass() instanceof ParameterizedType) {
-      return (ParameterizedType) classs.getGenericSuperclass();
-    }
-    return getParameterizedType((Class<?>) classs.getGenericSuperclass());
-  }
 
-  private static Class<?> getRawType(Object typeArgument) {
-    if (typeArgument instanceof ParameterizedType) {
-      return getRawType(((ParameterizedType) typeArgument).getRawType());
-    } else {
-      if (typeArgument instanceof Class<?>) {
-        return (Class<?>) typeArgument;
-      } else {
-        return null;
-      }
+    private static Class<?> getRawType(Object typeArgument) {
+        if (typeArgument instanceof ParameterizedType) {
+            return getRawType(((ParameterizedType) typeArgument).getRawType());
+        } else {
+            if (typeArgument instanceof Class<?>) {
+                return (Class<?>) typeArgument;
+            } else {
+                return null;
+            }
+        }
     }
-  }
 
-  private static String generateName(String name) {
-    if (counter == Integer.MAX_VALUE) {
-      counter = 0;
+    private static String generateName(String name) {
+        if (counter == Integer.MAX_VALUE) {
+            counter = 0;
+        }
+        return name + "_" + counter++ + "_";
     }
-    return name + "_" + counter++ + "_";
-  }
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/AbstractScriptlet.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/AbstractScriptlet.java
@@ -52,80 +52,58 @@ public abstract class AbstractScriptlet implements DRIScriptlet {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterColumnInit(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterDetailEval(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterGroupInit(String groupName, ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterPageInit(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void afterReportInit(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeColumnInit(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeDetailEval(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeGroupInit(String groupName, ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforePageInit(ReportParameters reportParameters) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void beforeReportInit(ReportParameters reportParameters) {
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/AbstractTemplateDesign.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/AbstractTemplateDesign.java
@@ -41,225 +41,169 @@ import java.util.List;
 public abstract class AbstractTemplateDesign<T> implements DRITemplateDesign<T> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getReportName() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIField<?>> getFields() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isDefinedParameter(String name) {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getResourceBundleName() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePagination() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenNoDataType getWhenNoDataType() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenResourceMissingType getWhenResourceMissingType() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleOnANewPage() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryOnANewPage() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryWithPageHeaderAndFooter() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFloatColumnFooter() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageWidth() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageHeight() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageOrientation getPageOrientation() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIMargin getPageMargin() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnsPerPage() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnSpace() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnWidth() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getTitleComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageHeaderComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPageFooterComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnHeaderComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getColumnFooterComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getLastPageFooterComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getSummaryComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getNoDataComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getBackgroundComponentsCount() {
         return 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T getDesign() throws DRException {
         return null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRBand.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRBand.java
@@ -49,9 +49,7 @@ public class DRBand implements DRIBand {
         this.list = new DRList(ListType.VERTICAL);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getSplitType() {
         return splitType;
@@ -66,9 +64,7 @@ public class DRBand implements DRIBand {
         this.splitType = splitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRList getList() {
         return list;
@@ -83,9 +79,7 @@ public class DRBand implements DRIBand {
         list.addComponent(component);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getPrintWhenExpression() {
         return printWhenExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRDataset.java
@@ -60,9 +60,7 @@ public class DRDataset implements DRIDataset {
         this.sorts = new ArrayList<DRSort>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRField<?>> getFields() {
         return fields;
@@ -89,9 +87,7 @@ public class DRDataset implements DRIDataset {
         this.fields.add(field);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRVariable<?>> getVariables() {
         return variables;
@@ -118,9 +114,7 @@ public class DRDataset implements DRIDataset {
         this.variables.add(variable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRSort> getSorts() {
         return sorts;
@@ -147,9 +141,7 @@ public class DRDataset implements DRIDataset {
         this.sorts.add(sort);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRQuery getQuery() {
         return query;
@@ -164,9 +156,7 @@ public class DRDataset implements DRIDataset {
         this.query = query;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Connection> getConnectionExpression() {
         return connectionExpression;
@@ -181,9 +171,7 @@ public class DRDataset implements DRIDataset {
         this.connectionExpression = connectionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getDataSourceExpression() {
         return dataSourceExpression;
@@ -198,9 +186,7 @@ public class DRDataset implements DRIDataset {
         this.dataSourceExpression = dataSourceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getFilterExpression() {
         return filterExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRField.java
@@ -53,9 +53,7 @@ public class DRField<T> implements DRIField<T> {
         this.valueClass = valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDataType<? super T, T> getDataType() {
         return dataType;
@@ -70,25 +68,19 @@ public class DRField<T> implements DRIField<T> {
         this.dataType = dataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getDescription() {
         return description;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRGroup.java
@@ -91,25 +91,19 @@ public class DRGroup implements DRIGroup {
         footerBand = new DRBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRTextField<?> getValueField() {
         return valueField;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getTitleExpression() {
         return titleExpression;
@@ -124,9 +118,7 @@ public class DRGroup implements DRIGroup {
         this.titleExpression = titleExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTitleStyle() {
         return titleStyle;
@@ -141,9 +133,7 @@ public class DRGroup implements DRIGroup {
         this.titleStyle = titleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTitleWidth() {
         return titleWidth;
@@ -158,9 +148,7 @@ public class DRGroup implements DRIGroup {
         this.titleWidth = titleWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupHeaderLayout getHeaderLayout() {
         return headerLayout;
@@ -175,9 +163,7 @@ public class DRGroup implements DRIGroup {
         this.headerLayout = headerLayout;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHideColumn() {
         return hideColumn;
@@ -192,9 +178,7 @@ public class DRGroup implements DRIGroup {
         this.hideColumn = hideColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupByDataType() {
         return groupByDataType;
@@ -209,9 +193,7 @@ public class DRGroup implements DRIGroup {
         this.groupByDataType = groupByDataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowColumnHeaderAndFooter() {
         return showColumnHeaderAndFooter;
@@ -226,9 +208,7 @@ public class DRGroup implements DRIGroup {
         this.showColumnHeaderAndFooter = showColumnHeaderAndFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getAddToTableOfContents() {
         return addToTableOfContents;
@@ -243,9 +223,7 @@ public class DRGroup implements DRIGroup {
         this.addToTableOfContents = addToTableOfContents;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getPrintSubtotalsWhenExpression() {
         return printSubtotalsWhenExpression;
@@ -260,9 +238,7 @@ public class DRGroup implements DRIGroup {
         this.printSubtotalsWhenExpression = printSubtotalsWhenExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPadding() {
         return padding;
@@ -280,9 +256,7 @@ public class DRGroup implements DRIGroup {
         this.padding = padding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStartInNewPage() {
         return startInNewPage;
@@ -297,9 +271,7 @@ public class DRGroup implements DRIGroup {
         this.startInNewPage = startInNewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStartInNewColumn() {
         return startInNewColumn;
@@ -314,9 +286,7 @@ public class DRGroup implements DRIGroup {
         this.startInNewColumn = startInNewColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getReprintHeaderOnEachPage() {
         return reprintHeaderOnEachPage;
@@ -331,9 +301,7 @@ public class DRGroup implements DRIGroup {
         this.reprintHeaderOnEachPage = reprintHeaderOnEachPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getResetPageNumber() {
         return resetPageNumber;
@@ -348,9 +316,7 @@ public class DRGroup implements DRIGroup {
         this.resetPageNumber = resetPageNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinHeightToStartNewPage() {
         return minHeightToStartNewPage;
@@ -365,9 +331,7 @@ public class DRGroup implements DRIGroup {
         this.minHeightToStartNewPage = minHeightToStartNewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupFooterPosition getFooterPosition() {
         return footerPosition;
@@ -382,9 +346,7 @@ public class DRGroup implements DRIGroup {
         this.footerPosition = footerPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getKeepTogether() {
         return keepTogether;
@@ -399,9 +361,7 @@ public class DRGroup implements DRIGroup {
         this.keepTogether = keepTogether;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHeaderWithSubtotal() {
         return headerWithSubtotal;
@@ -416,17 +376,13 @@ public class DRGroup implements DRIGroup {
         this.headerWithSubtotal = headerWithSubtotal;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getHeaderBand() {
         return headerBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getFooterBand() {
         return footerBand;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRHyperLink.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRHyperLink.java
@@ -41,9 +41,7 @@ public class DRHyperLink implements DRIHyperLink {
     private String hyperLinkType;
     private String hyperLinkTarget;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getAnchorExpression() {
         return anchorExpression;
@@ -58,9 +56,7 @@ public class DRHyperLink implements DRIHyperLink {
         this.anchorExpression = anchorExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Integer> getPageExpression() {
         return pageExpression;
@@ -75,9 +71,7 @@ public class DRHyperLink implements DRIHyperLink {
         this.pageExpression = pageExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getReferenceExpression() {
         return referenceExpression;
@@ -92,9 +86,7 @@ public class DRHyperLink implements DRIHyperLink {
         this.referenceExpression = referenceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getTooltipExpression() {
         return tooltipExpression;
@@ -109,9 +101,7 @@ public class DRHyperLink implements DRIHyperLink {
         this.tooltipExpression = tooltipExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getType() {
         return hyperLinkType;
@@ -126,9 +116,7 @@ public class DRHyperLink implements DRIHyperLink {
         this.hyperLinkType = hyperLinkType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTarget() {
         return hyperLinkTarget;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRMargin.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRMargin.java
@@ -58,9 +58,7 @@ public class DRMargin implements DRIMargin {
         right = margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getTop() {
         return top;
@@ -76,9 +74,7 @@ public class DRMargin implements DRIMargin {
         this.top = top;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getLeft() {
         return left;
@@ -94,9 +90,7 @@ public class DRMargin implements DRIMargin {
         this.left = left;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getBottom() {
         return bottom;
@@ -112,9 +106,7 @@ public class DRMargin implements DRIMargin {
         this.bottom = bottom;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getRight() {
         return right;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRPage.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRPage.java
@@ -90,7 +90,7 @@ public class DRPage implements DRIPage {
      * Sets the page width.
      *
      * @param width the page width >= 0
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public void setWidth(Integer width) {
@@ -114,7 +114,7 @@ public class DRPage implements DRIPage {
      * Sets the page height.
      *
      * @param height the page height >= 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public void setHeight(Integer height) {
@@ -124,9 +124,7 @@ public class DRPage implements DRIPage {
         this.height = height;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageOrientation getOrientation() {
         return orientation;
@@ -141,9 +139,7 @@ public class DRPage implements DRIPage {
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRMargin getMargin() {
         return margin;
@@ -158,9 +154,7 @@ public class DRPage implements DRIPage {
         this.margin = margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnsPerPage() {
         return columnsPerPage;
@@ -178,9 +172,7 @@ public class DRPage implements DRIPage {
         this.columnsPerPage = columnsPerPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnSpace() {
         return columnSpace;
@@ -198,9 +190,7 @@ public class DRPage implements DRIPage {
         this.columnSpace = columnSpace;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePageWidth() {
         return ignorePageWidth;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRParameter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRParameter.java
@@ -44,7 +44,8 @@ public class DRParameter<T> implements DRIParameter<T> {
      *
      * @param name a {@link java.lang.String} object.
      * @param value a T object.
-     */ public DRParameter(String name, T value) {
+     */
+    public DRParameter(String name, T value) {
         Validate.notEmpty(name, "name must not be empty");
         Validate.notNull(value, "value must not be null");
         this.name = name;
@@ -65,25 +66,19 @@ public class DRParameter<T> implements DRIParameter<T> {
         this.valueClass = valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<T> getValueClass() {
         return valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T getValue() {
         return value;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRQuery.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRQuery.java
@@ -50,17 +50,13 @@ public class DRQuery implements DRIQuery {
         this.language = language;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getText() {
         return text;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLanguage() {
         return language;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRReport.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRReport.java
@@ -159,9 +159,7 @@ public class DRReport implements DRIReport {
         backgroundBand = new DRBand();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRReportTemplate getTemplate() {
         return template;
@@ -177,9 +175,7 @@ public class DRReport implements DRIReport {
         this.template = template;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIStyle> getTemplateStyles() {
         return templateStyles;
@@ -205,9 +201,7 @@ public class DRReport implements DRIReport {
         this.templateStyles.add(templateStyle);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRITemplateDesign<?> getTemplateDesign() {
         return templateDesign;
@@ -223,9 +217,7 @@ public class DRReport implements DRIReport {
         this.templateDesign = templateDesign;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getReportName() {
         return reportName;
@@ -240,9 +232,7 @@ public class DRReport implements DRIReport {
         this.reportName = reportName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Locale getLocale() {
         return locale;
@@ -257,9 +247,7 @@ public class DRReport implements DRIReport {
         this.locale = locale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ResourceBundle getResourceBundle() {
         return resourceBundle;
@@ -274,9 +262,7 @@ public class DRReport implements DRIReport {
         this.resourceBundle = resourceBundle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getResourceBundleName() {
         return resourceBundleName;
@@ -291,9 +277,7 @@ public class DRReport implements DRIReport {
         this.resourceBundleName = resourceBundleName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowColumnTitle() {
         return showColumnTitle;
@@ -308,9 +292,7 @@ public class DRReport implements DRIReport {
         this.showColumnTitle = showColumnTitle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowColumnValues() {
         return showColumnValues;
@@ -325,9 +307,7 @@ public class DRReport implements DRIReport {
         this.showColumnValues = showColumnValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRColumn<?>> getColumns() {
         return columns;
@@ -354,9 +334,7 @@ public class DRReport implements DRIReport {
         this.columns.add(column);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRGroup> getGroups() {
         return groups;
@@ -383,9 +361,7 @@ public class DRReport implements DRIReport {
         this.groups.add(group);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRField<?>> getFields() {
         return fields;
@@ -412,9 +388,7 @@ public class DRReport implements DRIReport {
         this.fields.add(field);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRVariable<?>> getVariables() {
         return variables;
@@ -441,9 +415,7 @@ public class DRReport implements DRIReport {
         this.variables.add(variable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRSort> getSorts() {
         return sorts;
@@ -470,9 +442,7 @@ public class DRReport implements DRIReport {
         this.sorts.add(sort);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRSubtotal<?>> getSubtotals() {
         return subtotals;
@@ -499,9 +469,7 @@ public class DRReport implements DRIReport {
         this.subtotals.add(subtotal);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRParameter<?>> getParameters() {
         return parameters;
@@ -528,9 +496,7 @@ public class DRReport implements DRIReport {
         this.parameters.add(parameter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, Object> getParameterValues() {
         return parameterValues;
@@ -559,9 +525,7 @@ public class DRReport implements DRIReport {
         this.parameterValues.put(name, value);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIScriptlet> getScriptlets() {
         return scriptlets;
@@ -588,9 +552,7 @@ public class DRReport implements DRIReport {
         this.scriptlets.add(scriptlet);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Properties getProperties() {
         return properties;
@@ -617,9 +579,7 @@ public class DRReport implements DRIReport {
         this.properties.setProperty(key, value);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRQuery getQuery() {
         return query;
@@ -634,9 +594,7 @@ public class DRReport implements DRIReport {
         this.query = query;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPage getPage() {
         return page;
@@ -652,9 +610,7 @@ public class DRReport implements DRIReport {
         this.page = page;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePagination() {
         return ignorePagination;
@@ -669,9 +625,7 @@ public class DRReport implements DRIReport {
         this.ignorePagination = ignorePagination;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenNoDataType getWhenNoDataType() {
         return whenNoDataType;
@@ -686,9 +640,7 @@ public class DRReport implements DRIReport {
         this.whenNoDataType = whenNoDataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenResourceMissingType getWhenResourceMissingType() {
         return whenResourceMissingType;
@@ -703,9 +655,7 @@ public class DRReport implements DRIReport {
         this.whenResourceMissingType = whenResourceMissingType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleOnANewPage() {
         return titleOnANewPage;
@@ -720,9 +670,7 @@ public class DRReport implements DRIReport {
         this.titleOnANewPage = titleOnANewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryOnANewPage() {
         return summaryOnANewPage;
@@ -737,9 +685,7 @@ public class DRReport implements DRIReport {
         this.summaryOnANewPage = summaryOnANewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryWithPageHeaderAndFooter() {
         return summaryWithPageHeaderAndFooter;
@@ -754,9 +700,7 @@ public class DRReport implements DRIReport {
         this.summaryWithPageHeaderAndFooter = summaryWithPageHeaderAndFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFloatColumnFooter() {
         return floatColumnFooter;
@@ -771,9 +715,7 @@ public class DRReport implements DRIReport {
         this.floatColumnFooter = floatColumnFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Orientation getPrintOrder() {
         return printOrder;
@@ -788,9 +730,7 @@ public class DRReport implements DRIReport {
         this.printOrder = printOrder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getColumnDirection() {
         return columnDirection;
@@ -805,9 +745,7 @@ public class DRReport implements DRIReport {
         this.columnDirection = columnDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLanguage() {
         return language;
@@ -822,9 +760,7 @@ public class DRReport implements DRIReport {
         this.language = language;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUseFieldNameAsDescription() {
         return useFieldNameAsDescription;
@@ -839,9 +775,7 @@ public class DRReport implements DRIReport {
         this.useFieldNameAsDescription = useFieldNameAsDescription;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIFont getDefaultFont() {
         return defaultFont;
@@ -856,9 +790,7 @@ public class DRReport implements DRIReport {
         this.defaultFont = defaultFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTextStyle() {
         return textStyle;
@@ -873,9 +805,7 @@ public class DRReport implements DRIReport {
         this.textStyle = textStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnTitleStyle() {
         return columnTitleStyle;
@@ -890,9 +820,7 @@ public class DRReport implements DRIReport {
         this.columnTitleStyle = columnTitleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnStyle() {
         return columnStyle;
@@ -907,9 +835,7 @@ public class DRReport implements DRIReport {
         this.columnStyle = columnStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupTitleStyle() {
         return groupTitleStyle;
@@ -924,9 +850,7 @@ public class DRReport implements DRIReport {
         this.groupTitleStyle = groupTitleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupStyle() {
         return groupStyle;
@@ -941,9 +865,7 @@ public class DRReport implements DRIReport {
         this.groupStyle = groupStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getSubtotalStyle() {
         return subtotalStyle;
@@ -958,9 +880,7 @@ public class DRReport implements DRIReport {
         this.subtotalStyle = subtotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getImageStyle() {
         return imageStyle;
@@ -975,9 +895,7 @@ public class DRReport implements DRIReport {
         this.imageStyle = imageStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getChartStyle() {
         return chartStyle;
@@ -992,9 +910,7 @@ public class DRReport implements DRIReport {
         this.chartStyle = chartStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getBarcodeStyle() {
         return barcodeStyle;
@@ -1009,9 +925,7 @@ public class DRReport implements DRIReport {
         this.barcodeStyle = barcodeStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightDetailOddRows() {
         return highlightDetailOddRows;
@@ -1026,9 +940,7 @@ public class DRReport implements DRIReport {
         this.highlightDetailOddRows = highlightDetailOddRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getDetailOddRowStyle() {
         return detailOddRowStyle;
@@ -1043,9 +955,7 @@ public class DRReport implements DRIReport {
         this.detailOddRowStyle = detailOddRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightDetailEvenRows() {
         return highlightDetailEvenRows;
@@ -1060,9 +970,7 @@ public class DRReport implements DRIReport {
         this.highlightDetailEvenRows = highlightDetailEvenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getDetailEvenRowStyle() {
         return detailEvenRowStyle;
@@ -1077,9 +985,7 @@ public class DRReport implements DRIReport {
         this.detailEvenRowStyle = detailEvenRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRConditionalStyle> getDetailRowHighlighters() {
         return detailRowHighlighters;
@@ -1106,9 +1012,7 @@ public class DRReport implements DRIReport {
         this.detailRowHighlighters.add(detailRowHighlighter);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRColumnGrid getColumnGrid() {
         return columnGrid;
@@ -1123,9 +1027,7 @@ public class DRReport implements DRIReport {
         this.columnGrid = columnGrid;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTableOfContents() {
         return tableOfContents;
@@ -1140,9 +1042,7 @@ public class DRReport implements DRIReport {
         this.tableOfContents = tableOfContents;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRITableOfContentsCustomizer getTableOfContentsCustomizer() {
         return tableOfContentsCustomizer;
@@ -1157,9 +1057,7 @@ public class DRReport implements DRIReport {
         this.tableOfContentsCustomizer = tableOfContentsCustomizer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getFilterExpression() {
         return filterExpression;
@@ -1174,97 +1072,73 @@ public class DRReport implements DRIReport {
         this.filterExpression = filterExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getTitleBand() {
         return titleBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getPageHeaderBand() {
         return pageHeaderBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getPageFooterBand() {
         return pageFooterBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getColumnHeaderBand() {
         return columnHeaderBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getColumnFooterBand() {
         return columnFooterBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getDetailBand() {
         return detailBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getDetailHeaderBand() {
         return detailHeaderBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getDetailFooterBand() {
         return detailFooterBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getLastPageFooterBand() {
         return lastPageFooterBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getSummaryBand() {
         return summaryBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getNoDataBand() {
         return noDataBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBand getBackgroundBand() {
         return backgroundBand;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRReportTemplate.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRReportTemplate.java
@@ -209,9 +209,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartSeriesColors = new ArrayList<Color>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIStyle> getTemplateStyles() {
         return templateStyles;
@@ -237,9 +235,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.templateStyles.add(templateStyle);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Locale getLocale() {
         return locale;
@@ -254,9 +250,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.locale = locale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowColumnTitle() {
         return showColumnTitle;
@@ -271,9 +265,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.showColumnTitle = showColumnTitle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowColumnValues() {
         return showColumnValues;
@@ -288,9 +280,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.showColumnValues = showColumnValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePagination() {
         return ignorePagination;
@@ -305,9 +295,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.ignorePagination = ignorePagination;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenNoDataType getWhenNoDataType() {
         return whenNoDataType;
@@ -322,9 +310,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.whenNoDataType = whenNoDataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public WhenResourceMissingType getWhenResourceMissingType() {
         return whenResourceMissingType;
@@ -339,9 +325,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.whenResourceMissingType = whenResourceMissingType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleOnANewPage() {
         return titleOnANewPage;
@@ -356,9 +340,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.titleOnANewPage = titleOnANewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryOnANewPage() {
         return summaryOnANewPage;
@@ -373,9 +355,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.summaryOnANewPage = summaryOnANewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getSummaryWithPageHeaderAndFooter() {
         return summaryWithPageHeaderAndFooter;
@@ -390,9 +370,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.summaryWithPageHeaderAndFooter = summaryWithPageHeaderAndFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getFloatColumnFooter() {
         return floatColumnFooter;
@@ -407,9 +385,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.floatColumnFooter = floatColumnFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Orientation getPrintOrder() {
         return printOrder;
@@ -424,9 +400,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.printOrder = printOrder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getColumnDirection() {
         return columnDirection;
@@ -441,9 +415,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnDirection = columnDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLanguage() {
         return language;
@@ -458,9 +430,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.language = language;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUseFieldNameAsDescription() {
         return useFieldNameAsDescription;
@@ -475,9 +445,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.useFieldNameAsDescription = useFieldNameAsDescription;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightDetailOddRows() {
         return highlightDetailOddRows;
@@ -492,9 +460,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.highlightDetailOddRows = highlightDetailOddRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getDetailOddRowStyle() {
         return detailOddRowStyle;
@@ -509,9 +475,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailOddRowStyle = detailOddRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightDetailEvenRows() {
         return highlightDetailEvenRows;
@@ -526,9 +490,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.highlightDetailEvenRows = highlightDetailEvenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getDetailEvenRowStyle() {
         return detailEvenRowStyle;
@@ -543,9 +505,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailEvenRowStyle = detailEvenRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIFont getDefaultFont() {
         return defaultFont;
@@ -560,9 +520,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.defaultFont = defaultFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTextStyle() {
         return textStyle;
@@ -577,9 +535,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.textStyle = textStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnTitleStyle() {
         return columnTitleStyle;
@@ -594,9 +550,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnTitleStyle = columnTitleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnStyle() {
         return columnStyle;
@@ -611,9 +565,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnStyle = columnStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupTitleStyle() {
         return groupTitleStyle;
@@ -628,9 +580,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupTitleStyle = groupTitleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupStyle() {
         return groupStyle;
@@ -645,9 +595,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupStyle = groupStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getSubtotalStyle() {
         return subtotalStyle;
@@ -662,9 +610,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.subtotalStyle = subtotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getImageStyle() {
         return imageStyle;
@@ -679,9 +625,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.imageStyle = imageStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getChartStyle() {
         return chartStyle;
@@ -696,9 +640,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartStyle = chartStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getBarcodeStyle() {
         return barcodeStyle;
@@ -732,9 +674,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         setPageOrientation(orientation);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageWidth() {
         return pageWidth;
@@ -747,9 +687,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageWidth = pageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageHeight() {
         return pageHeight;
@@ -762,9 +700,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageHeight = pageHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public PageOrientation getPageOrientation() {
         return pageOrientation;
@@ -774,9 +710,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageOrientation = pageOrientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRMargin getPageMargin() {
         return pageMargin;
@@ -791,9 +725,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageMargin = pageMargin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnsPerPage() {
         return pageColumnsPerPage;
@@ -811,9 +743,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageColumnsPerPage = pageColumnsPerPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageColumnSpace() {
         return pageColumnSpace;
@@ -831,9 +761,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageColumnSpace = pageColumnSpace;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnorePageWidth() {
         return ignorePageWidth;
@@ -848,9 +776,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.ignorePageWidth = ignorePageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getColumnPrintRepeatedDetailValues() {
         return columnPrintRepeatedDetailValues;
@@ -865,9 +791,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnPrintRepeatedDetailValues = columnPrintRepeatedDetailValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnWidth() {
         return columnWidth;
@@ -885,9 +809,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnWidth = columnWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupHeaderLayout getGroupHeaderLayout() {
         return groupHeaderLayout;
@@ -902,9 +824,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHeaderLayout = groupHeaderLayout;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupHideColumn() {
         return groupHideColumn;
@@ -919,9 +839,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHideColumn = groupHideColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupShowColumnHeaderAndFooter() {
         return groupShowColumnHeaderAndFooter;
@@ -936,9 +854,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupShowColumnHeaderAndFooter = groupShowColumnHeaderAndFooter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getGroupPadding() {
         return groupPadding;
@@ -956,9 +872,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupPadding = groupPadding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupStartInNewPage() {
         return groupStartInNewPage;
@@ -973,9 +887,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupStartInNewPage = groupStartInNewPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupStartInNewColumn() {
         return groupStartInNewColumn;
@@ -990,9 +902,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupStartInNewColumn = groupStartInNewColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupReprintHeaderOnEachPage() {
         return groupReprintHeaderOnEachPage;
@@ -1007,9 +917,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupReprintHeaderOnEachPage = groupReprintHeaderOnEachPage;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupResetPageNumber() {
         return groupResetPageNumber;
@@ -1024,9 +932,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupResetPageNumber = groupResetPageNumber;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public GroupFooterPosition getGroupFooterPosition() {
         return groupFooterPosition;
@@ -1041,9 +947,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupFooterPosition = groupFooterPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupKeepTogether() {
         return groupKeepTogether;
@@ -1058,9 +962,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupKeepTogether = groupKeepTogether;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getGroupHeaderWithSubtotal() {
         return groupHeaderWithSubtotal;
@@ -1075,9 +977,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHeaderWithSubtotal = groupHeaderWithSubtotal;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getSubtotalLabelPosition() {
         return subtotalLabelPosition;
@@ -1092,9 +992,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.subtotalLabelPosition = subtotalLabelPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTableOfContents() {
         return tableOfContents;
@@ -1109,9 +1007,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.tableOfContents = tableOfContents;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRITableOfContentsCustomizer getTableOfContentsCustomizer() {
         return tableOfContentsCustomizer;
@@ -1126,9 +1022,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.tableOfContentsCustomizer = tableOfContentsCustomizer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTextFieldWidth() {
         return textFieldWidth;
@@ -1146,9 +1040,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.textFieldWidth = textFieldWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getImageHeight() {
         return imageHeight;
@@ -1166,9 +1058,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.imageHeight = imageHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getImageWidth() {
         return imageWidth;
@@ -1186,9 +1076,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.imageWidth = imageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getListgap() {
         return listgap;
@@ -1206,9 +1094,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.listgap = listgap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMultiPageListWidth() {
         return multiPageListWidth;
@@ -1223,9 +1109,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.multiPageListWidth = multiPageListWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMultiPageListHeight() {
         return multiPageListHeight;
@@ -1240,9 +1124,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.multiPageListHeight = multiPageListHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getChartHeight() {
         return chartHeight;
@@ -1260,9 +1142,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartHeight = chartHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getChartWidth() {
         return chartWidth;
@@ -1280,9 +1160,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartWidth = chartWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<Color> getChartSeriesColors() {
         return chartSeriesColors;
@@ -1310,9 +1188,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartSeriesColors.add(color);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getChartValuePattern() {
         return chartValuePattern;
@@ -1327,9 +1203,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartValuePattern = chartValuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getChartPercentValuePattern() {
         return chartPercentValuePattern;
@@ -1344,9 +1218,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartPercentValuePattern = chartPercentValuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getChartTheme() {
         return chartTheme;
@@ -1361,9 +1233,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.chartTheme = chartTheme;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarcodeHeight() {
         return barcodeHeight;
@@ -1381,9 +1251,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.barcodeHeight = barcodeHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarcodeWidth() {
         return barcodeWidth;
@@ -1401,9 +1269,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.barcodeWidth = barcodeWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSubreportHeight() {
         return subreportHeight;
@@ -1421,9 +1287,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.subreportHeight = subreportHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSubreportWidth() {
         return subreportWidth;
@@ -1441,9 +1305,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.subreportWidth = subreportWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getCrosstabHeight() {
         return crosstabHeight;
@@ -1461,9 +1323,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabHeight = crosstabHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getCrosstabWidth() {
         return crosstabWidth;
@@ -1481,9 +1341,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabWidth = crosstabWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCrosstabHighlightOddRows() {
         return crosstabHighlightOddRows;
@@ -1498,9 +1356,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabHighlightOddRows = crosstabHighlightOddRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getCrosstabOddRowStyle() {
         return crosstabOddRowStyle;
@@ -1515,9 +1371,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabOddRowStyle = crosstabOddRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCrosstabHighlightEvenRows() {
         return crosstabHighlightEvenRows;
@@ -1532,9 +1386,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabHighlightEvenRows = crosstabHighlightEvenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getCrosstabEvenRowStyle() {
         return crosstabEvenRowStyle;
@@ -1549,9 +1401,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabEvenRowStyle = crosstabEvenRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCrosstabGroupStyle() {
         return crosstabGroupStyle;
@@ -1566,9 +1416,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabGroupStyle = crosstabGroupStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCrosstabGroupTotalStyle() {
         return crosstabGroupTotalStyle;
@@ -1583,9 +1431,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabGroupTotalStyle = crosstabGroupTotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCrosstabGrandTotalStyle() {
         return crosstabGrandTotalStyle;
@@ -1600,9 +1446,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabGrandTotalStyle = crosstabGrandTotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCrosstabCellStyle() {
         return crosstabCellStyle;
@@ -1617,9 +1461,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabCellStyle = crosstabCellStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCrosstabMeasureTitleStyle() {
         return crosstabMeasureTitleStyle;
@@ -1634,9 +1476,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.crosstabMeasureTitleStyle = crosstabMeasureTitleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BooleanComponentType getBooleanComponentType() {
         return booleanComponentType;
@@ -1651,9 +1491,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.booleanComponentType = booleanComponentType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getBooleanEmptyWhenNullValue() {
         return booleanEmptyWhenNullValue;
@@ -1668,9 +1506,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.booleanEmptyWhenNullValue = booleanEmptyWhenNullValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBooleanImageWidth() {
         return booleanImageWidth;
@@ -1685,9 +1521,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.booleanImageWidth = booleanImageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBooleanImageHeight() {
         return booleanImageHeight;
@@ -1702,9 +1536,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.booleanImageHeight = booleanImageHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getBooleanColumnStyle() {
         return booleanColumnStyle;
@@ -1719,9 +1551,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.booleanColumnStyle = booleanColumnStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getDefaultSplitType() {
         return defaultSplitType;
@@ -1736,9 +1566,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.defaultSplitType = defaultSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getTitleSplitType() {
         return titleSplitType;
@@ -1753,9 +1581,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.titleSplitType = titleSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getPageHeaderSplitType() {
         return pageHeaderSplitType;
@@ -1770,9 +1596,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageHeaderSplitType = pageHeaderSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getPageFooterSplitType() {
         return pageFooterSplitType;
@@ -1787,9 +1611,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageFooterSplitType = pageFooterSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getColumnHeaderSplitType() {
         return columnHeaderSplitType;
@@ -1804,9 +1626,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnHeaderSplitType = columnHeaderSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getColumnFooterSplitType() {
         return columnFooterSplitType;
@@ -1821,9 +1641,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnFooterSplitType = columnFooterSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getGroupHeaderSplitType() {
         return groupHeaderSplitType;
@@ -1838,9 +1656,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHeaderSplitType = groupHeaderSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getGroupFooterSplitType() {
         return groupFooterSplitType;
@@ -1855,9 +1671,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupFooterSplitType = groupFooterSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getDetailHeaderSplitType() {
         return detailHeaderSplitType;
@@ -1872,9 +1686,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailHeaderSplitType = detailHeaderSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getDetailSplitType() {
         return detailSplitType;
@@ -1889,9 +1701,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailSplitType = detailSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getDetailFooterSplitType() {
         return detailFooterSplitType;
@@ -1906,9 +1716,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailFooterSplitType = detailFooterSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getLastPageFooterSplitType() {
         return lastPageFooterSplitType;
@@ -1923,9 +1731,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.lastPageFooterSplitType = lastPageFooterSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getSummarySplitType() {
         return summarySplitType;
@@ -1940,9 +1746,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.summarySplitType = summarySplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getNoDataSplitType() {
         return noDataSplitType;
@@ -1957,9 +1761,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.noDataSplitType = noDataSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getBackgroundSplitType() {
         return backgroundSplitType;
@@ -1974,9 +1776,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.backgroundSplitType = backgroundSplitType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTitleStyle() {
         return titleStyle;
@@ -1991,9 +1791,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.titleStyle = titleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getPageHeaderStyle() {
         return pageHeaderStyle;
@@ -2008,9 +1806,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageHeaderStyle = pageHeaderStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getPageFooterStyle() {
         return pageFooterStyle;
@@ -2025,9 +1821,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageFooterStyle = pageFooterStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnHeaderStyle() {
         return columnHeaderStyle;
@@ -2042,9 +1836,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnHeaderStyle = columnHeaderStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getColumnFooterStyle() {
         return columnFooterStyle;
@@ -2059,9 +1851,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnFooterStyle = columnFooterStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupHeaderStyle() {
         return groupHeaderStyle;
@@ -2076,9 +1866,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHeaderStyle = groupHeaderStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupFooterStyle() {
         return groupFooterStyle;
@@ -2093,9 +1881,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupFooterStyle = groupFooterStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getDetailHeaderStyle() {
         return detailHeaderStyle;
@@ -2110,9 +1896,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailHeaderStyle = detailHeaderStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getDetailStyle() {
         return detailStyle;
@@ -2127,9 +1911,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailStyle = detailStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getDetailFooterStyle() {
         return detailFooterStyle;
@@ -2144,9 +1926,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailFooterStyle = detailFooterStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getLastPageFooterStyle() {
         return lastPageFooterStyle;
@@ -2161,9 +1941,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.lastPageFooterStyle = lastPageFooterStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getSummaryStyle() {
         return summaryStyle;
@@ -2178,9 +1956,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.summaryStyle = summaryStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getNoDataStyle() {
         return noDataStyle;
@@ -2195,9 +1971,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.noDataStyle = noDataStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getBackgroundStyle() {
         return backgroundStyle;
@@ -2212,9 +1986,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.backgroundStyle = backgroundStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getTitleBackgroundComponent() {
         return titleBackgroundComponent;
@@ -2229,9 +2001,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.titleBackgroundComponent = titleBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getPageHeaderBackgroundComponent() {
         return pageHeaderBackgroundComponent;
@@ -2246,9 +2016,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageHeaderBackgroundComponent = pageHeaderBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getPageFooterBackgroundComponent() {
         return pageFooterBackgroundComponent;
@@ -2263,9 +2031,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.pageFooterBackgroundComponent = pageFooterBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getColumnHeaderBackgroundComponent() {
         return columnHeaderBackgroundComponent;
@@ -2280,9 +2046,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnHeaderBackgroundComponent = columnHeaderBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getColumnFooterBackgroundComponent() {
         return columnFooterBackgroundComponent;
@@ -2297,9 +2061,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.columnFooterBackgroundComponent = columnFooterBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getGroupHeaderBackgroundComponent() {
         return groupHeaderBackgroundComponent;
@@ -2314,9 +2076,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupHeaderBackgroundComponent = groupHeaderBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getGroupFooterBackgroundComponent() {
         return groupFooterBackgroundComponent;
@@ -2331,9 +2091,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.groupFooterBackgroundComponent = groupFooterBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getDetailHeaderBackgroundComponent() {
         return detailHeaderBackgroundComponent;
@@ -2348,9 +2106,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailHeaderBackgroundComponent = detailHeaderBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getDetailBackgroundComponent() {
         return detailBackgroundComponent;
@@ -2365,9 +2121,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailBackgroundComponent = detailBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getDetailFooterBackgroundComponent() {
         return detailFooterBackgroundComponent;
@@ -2382,9 +2136,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.detailFooterBackgroundComponent = detailFooterBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getLastPageFooterBackgroundComponent() {
         return lastPageFooterBackgroundComponent;
@@ -2399,9 +2151,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.lastPageFooterBackgroundComponent = lastPageFooterBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getSummaryBackgroundComponent() {
         return summaryBackgroundComponent;
@@ -2416,9 +2166,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.summaryBackgroundComponent = summaryBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getNoDataBackgroundComponent() {
         return noDataBackgroundComponent;
@@ -2433,9 +2181,7 @@ public class DRReportTemplate implements DRIReportTemplate {
         this.noDataBackgroundComponent = noDataBackgroundComponent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getBackgroundBackgroundComponent() {
         return backgroundBackgroundComponent;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRSort.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRSort.java
@@ -38,9 +38,7 @@ public class DRSort implements DRISort {
     private DRIExpression<?> expression;
     private OrderType orderType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getExpression() {
         return expression;
@@ -55,9 +53,7 @@ public class DRSort implements DRISort {
         this.expression = expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OrderType getOrderType() {
         return orderType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRSubtotal.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRSubtotal.java
@@ -66,9 +66,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         valueField = new DRTextField<T>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRColumn<?> getShowInColumn() {
         return showInColumn;
@@ -84,17 +82,13 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.showInColumn = showInColumn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRTextField<T> getValueField() {
         return valueField;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getLabelExpression() {
         return labelExpression;
@@ -109,9 +103,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.labelExpression = labelExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getLabelStyle() {
         return labelStyle;
@@ -126,9 +118,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.labelStyle = labelStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getLabelPosition() {
         return labelPosition;
@@ -143,9 +133,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.labelPosition = labelPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getLabelWidth() {
         return labelWidth;
@@ -160,9 +148,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.labelWidth = labelWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getLabelWidthType() {
         return labelWidthType;
@@ -177,9 +163,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.labelWidthType = labelWidthType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SubtotalPosition getPosition() {
         return position;
@@ -195,9 +179,7 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.position = position;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRGroup getGroup() {
         return group;
@@ -212,17 +194,13 @@ public class DRSubtotal<T> implements DRISubtotal<T> {
         this.group = group;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return valueField.getValueExpression().getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return valueField.getValueExpression().getValueClass();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRTableOfContentsHeading.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRTableOfContentsHeading.java
@@ -38,9 +38,7 @@ public class DRTableOfContentsHeading implements DRITableOfContentsHeading {
     private DRIExpression<String> labelExpression;
     private DRIExpression<?> customValueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRTableOfContentsHeading getParentHeading() {
         return parentHeading;
@@ -55,9 +53,7 @@ public class DRTableOfContentsHeading implements DRITableOfContentsHeading {
         this.parentHeading = parentHeading;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getLabelExpression() {
         return labelExpression;
@@ -72,9 +68,7 @@ public class DRTableOfContentsHeading implements DRITableOfContentsHeading {
         this.labelExpression = labelExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getCustomValueExpression() {
         return customValueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRVariable.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/DRVariable.java
@@ -71,17 +71,13 @@ public class DRVariable<T> implements DRIVariable<T> {
         this.calculation = calculation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getInitialValueExpression() {
         return initialValueExpression;
@@ -96,17 +92,13 @@ public class DRVariable<T> implements DRIVariable<T> {
         this.initialValueExpression = initialValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Calculation getCalculation() {
         return calculation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Evaluation getResetType() {
         return resetType;
@@ -121,9 +113,7 @@ public class DRVariable<T> implements DRIVariable<T> {
         this.resetType = resetType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRGroup getResetGroup() {
         return resetGroup;
@@ -138,17 +128,13 @@ public class DRVariable<T> implements DRIVariable<T> {
         this.resetGroup = resetGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<? super T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarbecue.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarbecue.java
@@ -46,9 +46,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
     private Integer barHeight;
     private BarcodeOrientation orientation;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarbecueType getType() {
         return type;
@@ -63,9 +61,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getCodeExpression() {
         return codeExpression;
@@ -80,9 +76,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.codeExpression = codeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getApplicationIdentifierExpression() {
         return applicationIdentifierExpression;
@@ -97,9 +91,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.applicationIdentifierExpression = applicationIdentifierExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDrawText() {
         return drawText;
@@ -114,9 +106,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.drawText = drawText;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getChecksumRequired() {
         return checksumRequired;
@@ -131,9 +121,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.checksumRequired = checksumRequired;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarWidth() {
         return barWidth;
@@ -148,9 +136,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.barWidth = barWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBarHeight() {
         return barHeight;
@@ -165,9 +151,7 @@ public class DRBarbecue extends DRDimensionComponent implements DRIBarbecue {
         this.barHeight = barHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeOrientation getOrientation() {
         return orientation;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarcode.java
@@ -38,9 +38,7 @@ public abstract class DRBarcode extends DRDimensionComponent implements DRIBarco
 
     private DRIExpression<String> codeExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getCodeExpression() {
         return codeExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarcode4j.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRBarcode4j.java
@@ -43,9 +43,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
     private Double quietZone;
     private Double verticalQuietZone;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getPatternExpression() {
         return patternExpression;
@@ -60,9 +58,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
         this.patternExpression = patternExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getModuleWidth() {
         return moduleWidth;
@@ -77,9 +73,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
         this.moduleWidth = moduleWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeOrientation getOrientation() {
         return orientation;
@@ -94,9 +88,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
         this.orientation = orientation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeTextPosition getTextPosition() {
         return textPosition;
@@ -111,9 +103,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
         this.textPosition = textPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getQuietZone() {
         return quietZone;
@@ -128,9 +118,7 @@ public abstract class DRBarcode4j extends DRBarcode implements DRIBarcode4j {
         this.quietZone = quietZone;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getVerticalQuietZone() {
         return verticalQuietZone;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRChecksumBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRChecksumBarcode.java
@@ -36,9 +36,7 @@ public abstract class DRChecksumBarcode extends DRBarcode4j implements DRIChecks
 
     private BarcodeChecksumMode checksumMode;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeChecksumMode getChecksumMode() {
         return checksumMode;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRCodabarBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRCodabarBarcode.java
@@ -35,9 +35,7 @@ public class DRCodabarBarcode extends DRBarcode4j implements DRICodabarBarcode {
 
     private Double wideFactor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRCode39Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRCode39Barcode.java
@@ -39,9 +39,7 @@ public class DRCode39Barcode extends DRChecksumBarcode implements DRICode39Barco
     private Double intercharGapWidth;
     private Double wideFactor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -56,9 +54,7 @@ public class DRCode39Barcode extends DRChecksumBarcode implements DRICode39Barco
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayStartStop() {
         return displayStartStop;
@@ -73,9 +69,7 @@ public class DRCode39Barcode extends DRChecksumBarcode implements DRICode39Barco
         this.displayStartStop = displayStartStop;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getExtendedCharSetEnabled() {
         return extendedCharSetEnabled;
@@ -90,9 +84,7 @@ public class DRCode39Barcode extends DRChecksumBarcode implements DRICode39Barco
         this.extendedCharSetEnabled = extendedCharSetEnabled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -107,9 +99,7 @@ public class DRCode39Barcode extends DRChecksumBarcode implements DRICode39Barco
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRDataMatrixBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRDataMatrixBarcode.java
@@ -36,9 +36,7 @@ public class DRDataMatrixBarcode extends DRBarcode4j implements DRIDataMatrixBar
 
     private BarcodeShape shape;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeShape getShape() {
         return shape;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRInterleaved2Of5Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRInterleaved2Of5Barcode.java
@@ -36,9 +36,7 @@ public class DRInterleaved2Of5Barcode extends DRChecksumBarcode implements DRIIn
     private Boolean displayChecksum;
     private Double wideFactor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -53,9 +51,7 @@ public class DRInterleaved2Of5Barcode extends DRChecksumBarcode implements DRIIn
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWideFactor() {
         return wideFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRPdf417Barcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRPdf417Barcode.java
@@ -40,9 +40,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
     private Double widthToHeightRatio;
     private Integer errorCorrectionLevel;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinColumns() {
         return minColumns;
@@ -57,9 +55,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
         this.minColumns = minColumns;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMaxColumns() {
         return maxColumns;
@@ -74,9 +70,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
         this.maxColumns = maxColumns;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMinRows() {
         return minRows;
@@ -91,9 +85,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
         this.minRows = minRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMaxRows() {
         return maxRows;
@@ -108,9 +100,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
         this.maxRows = maxRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getWidthToHeightRatio() {
         return widthToHeightRatio;
@@ -125,9 +115,7 @@ public class DRPdf417Barcode extends DRBarcode4j implements DRIPdf417Barcode {
         this.widthToHeightRatio = widthToHeightRatio;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getErrorCorrectionLevel() {
         return errorCorrectionLevel;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRPostnetBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRPostnetBarcode.java
@@ -39,9 +39,7 @@ public class DRPostnetBarcode extends DRChecksumBarcode implements DRIPostnetBar
     private BarcodeBaselinePosition baselinePosition;
     private Double intercharGapWidth;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDisplayChecksum() {
         return displayChecksum;
@@ -56,9 +54,7 @@ public class DRPostnetBarcode extends DRChecksumBarcode implements DRIPostnetBar
         this.displayChecksum = displayChecksum;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getShortBarHeight() {
         return shortBarHeight;
@@ -73,9 +69,7 @@ public class DRPostnetBarcode extends DRChecksumBarcode implements DRIPostnetBar
         this.shortBarHeight = shortBarHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BarcodeBaselinePosition getBaselinePosition() {
         return baselinePosition;
@@ -90,9 +84,7 @@ public class DRPostnetBarcode extends DRChecksumBarcode implements DRIPostnetBar
         this.baselinePosition = baselinePosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRQrCode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRQrCode.java
@@ -37,9 +37,7 @@ public class DRQrCode extends DRBarcode implements DRIQrCode {
     private Integer margin;
     private QrCodeErrorCorrectionLevel errorCorrectionLevel;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMargin() {
         return margin;
@@ -54,9 +52,7 @@ public class DRQrCode extends DRBarcode implements DRIQrCode {
         this.margin = margin;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public QrCodeErrorCorrectionLevel getErrorCorrectionLevel() {
         return errorCorrectionLevel;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRRoyalMailCustomerBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRRoyalMailCustomerBarcode.java
@@ -37,9 +37,7 @@ public class DRRoyalMailCustomerBarcode extends DRChecksumBarcode implements DRI
     private Double intercharGapWidth;
     private Double trackHeight;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAscenderHeight() {
         return ascenderHeight;
@@ -54,9 +52,7 @@ public class DRRoyalMailCustomerBarcode extends DRChecksumBarcode implements DRI
         this.ascenderHeight = ascenderHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -71,9 +67,7 @@ public class DRRoyalMailCustomerBarcode extends DRChecksumBarcode implements DRI
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTrackHeight() {
         return trackHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRUspsIntelligentMailBarcode.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/barcode/DRUspsIntelligentMailBarcode.java
@@ -37,9 +37,7 @@ public class DRUspsIntelligentMailBarcode extends DRChecksumBarcode implements D
     private Double intercharGapWidth;
     private Double trackHeight;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAscenderHeight() {
         return ascenderHeight;
@@ -54,9 +52,7 @@ public class DRUspsIntelligentMailBarcode extends DRChecksumBarcode implements D
         this.ascenderHeight = ascenderHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getIntercharGapWidth() {
         return intercharGapWidth;
@@ -71,9 +67,7 @@ public class DRUspsIntelligentMailBarcode extends DRChecksumBarcode implements D
         this.intercharGapWidth = intercharGapWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTrackHeight() {
         return trackHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChart.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChart.java
@@ -85,9 +85,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         setChartType(chartType);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
@@ -97,9 +95,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         this.legend = new DRChartLegend();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ChartType getChartType() {
         return chartType;
@@ -218,25 +214,19 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRChartDataset getDataset() {
         return dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIPlot getPlot() {
         return plot;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIChartCustomizer> getCustomizers() {
         return customizers;
@@ -260,9 +250,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         this.customizers.add(customizer);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRChartTitle getTitle() {
         return title;
@@ -278,9 +266,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         this.title = title;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRChartSubtitle getSubtitle() {
         return subtitle;
@@ -296,9 +282,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         this.subtitle = subtitle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRChartLegend getLegend() {
         return legend;
@@ -314,9 +298,7 @@ public class DRChart extends DRHyperLinkComponent implements DRIChart {
         this.legend = legend;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTheme() {
         return theme;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartLegend.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartLegend.java
@@ -49,9 +49,7 @@ public class DRChartLegend implements DRIChartLegend {
     public DRChartLegend() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getColor() {
         return color;
@@ -66,9 +64,7 @@ public class DRChartLegend implements DRIChartLegend {
         this.color = color;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -83,9 +79,7 @@ public class DRChartLegend implements DRIChartLegend {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLegend() {
         return showLegend;
@@ -100,9 +94,7 @@ public class DRChartLegend implements DRIChartLegend {
         this.showLegend = showLegend;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getFont() {
         return font;
@@ -117,9 +109,7 @@ public class DRChartLegend implements DRIChartLegend {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getPosition() {
         return position;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartSubtitle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartSubtitle.java
@@ -41,9 +41,7 @@ public class DRChartSubtitle implements DRIChartSubtitle {
     private DRFont font;
     private DRIExpression<String> title;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getColor() {
         return color;
@@ -58,9 +56,7 @@ public class DRChartSubtitle implements DRIChartSubtitle {
         this.color = color;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getFont() {
         return font;
@@ -75,9 +71,7 @@ public class DRChartSubtitle implements DRIChartSubtitle {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getTitle() {
         return title;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartTitle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/DRChartTitle.java
@@ -36,9 +36,7 @@ public class DRChartTitle extends DRChartSubtitle implements DRIChartTitle {
 
     private Position position;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Position getPosition() {
         return position;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRCategoryChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRCategoryChartSerie.java
@@ -38,9 +38,7 @@ public class DRCategoryChartSerie extends DRChartSerie implements DRICategoryCha
     private DRIExpression<?> valueExpression;
     private DRIExpression<?> labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;
@@ -56,9 +54,7 @@ public class DRCategoryChartSerie extends DRChartSerie implements DRICategoryCha
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRCategoryDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRCategoryDataset.java
@@ -35,9 +35,7 @@ public class DRCategoryDataset extends DRSeriesDataset implements DRICategoryDat
 
     private Boolean useSeriesAsCategory;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUseSeriesAsCategory() {
         return useSeriesAsCategory;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRChartDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRChartDataset.java
@@ -36,9 +36,7 @@ public class DRChartDataset implements DRIChartDataset {
 
     private DRDataset subDataset;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDataset getSubDataset() {
         return subDataset;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRChartSerie.java
@@ -39,9 +39,7 @@ public abstract class DRChartSerie implements DRIChartSerie {
     private DRIExpression<?> seriesExpression;
     private DRIHyperLink itemHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getSeriesExpression() {
         return seriesExpression;
@@ -57,9 +55,7 @@ public abstract class DRChartSerie implements DRIChartSerie {
         this.seriesExpression = seriesExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIHyperLink getItemHyperLink() {
         return itemHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRGanttChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRGanttChartSerie.java
@@ -39,9 +39,7 @@ public class DRGanttChartSerie extends DRChartSerie implements DRIGanttChartSeri
     private DRIExpression<?> percentExpression;
     private DRIExpression<?> labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getStartDateExpression() {
         return startDateExpression;
@@ -56,9 +54,7 @@ public class DRGanttChartSerie extends DRChartSerie implements DRIGanttChartSeri
         this.startDateExpression = startDateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getEndDateExpression() {
         return endDateExpression;
@@ -73,9 +69,7 @@ public class DRGanttChartSerie extends DRChartSerie implements DRIGanttChartSeri
         this.endDateExpression = endDateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getPercentExpression() {
         return percentExpression;
@@ -90,9 +84,7 @@ public class DRGanttChartSerie extends DRChartSerie implements DRIGanttChartSeri
         this.percentExpression = percentExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRGroupedCategoryChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRGroupedCategoryChartSerie.java
@@ -37,9 +37,7 @@ public class DRGroupedCategoryChartSerie extends DRCategoryChartSerie implements
 
     private DRIExpression<?> groupExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getGroupExpression() {
         return groupExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRHighLowDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRHighLowDataset.java
@@ -44,9 +44,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
     private DRIExpression<?> volumeExpression;
     private DRIHyperLink itemHyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getSeriesExpression() {
         return seriesExpression;
@@ -61,9 +59,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.seriesExpression = seriesExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getDateExpression() {
         return dateExpression;
@@ -78,9 +74,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.dateExpression = dateExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getHighExpression() {
         return highExpression;
@@ -95,9 +89,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.highExpression = highExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getLowExpression() {
         return lowExpression;
@@ -112,9 +104,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.lowExpression = lowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getOpenExpression() {
         return openExpression;
@@ -129,9 +119,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.openExpression = openExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getCloseExpression() {
         return closeExpression;
@@ -146,9 +134,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.closeExpression = closeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getVolumeExpression() {
         return volumeExpression;
@@ -163,9 +149,7 @@ public class DRHighLowDataset extends DRChartDataset implements DRIHighLowDatase
         this.volumeExpression = volumeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIHyperLink getItemHyperLink() {
         return itemHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRSeriesDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRSeriesDataset.java
@@ -51,9 +51,7 @@ public class DRSeriesDataset extends DRChartDataset implements DRISeriesDataset 
         series = new ArrayList<DRIChartSerie>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;
@@ -79,17 +77,13 @@ public class DRSeriesDataset extends DRChartDataset implements DRISeriesDataset 
         series.add(serie);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIChartSerie> getSeries() {
         return series;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIHyperLink getItemHyperLink() {
         return itemHyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRTimeSeriesDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRTimeSeriesDataset.java
@@ -36,9 +36,7 @@ public class DRTimeSeriesDataset extends DRSeriesDataset implements DRITimeSerie
 
     private TimePeriod timePeriodType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TimePeriod getTimePeriodType() {
         return timePeriodType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRValueDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRValueDataset.java
@@ -37,9 +37,7 @@ public class DRValueDataset extends DRChartDataset implements DRIValueDataset {
 
     private DRIExpression<?> valueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRXyChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRXyChartSerie.java
@@ -39,9 +39,7 @@ public class DRXyChartSerie extends DRChartSerie implements DRIXyChartSerie {
     private DRIExpression<?> yValueExpression;
     private DRIExpression<?> labelExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getXValueExpression() {
         return xValueExpression;
@@ -57,9 +55,7 @@ public class DRXyChartSerie extends DRChartSerie implements DRIXyChartSerie {
         this.xValueExpression = xValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getYValueExpression() {
         return yValueExpression;
@@ -75,9 +71,7 @@ public class DRXyChartSerie extends DRChartSerie implements DRIXyChartSerie {
         this.yValueExpression = yValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getLabelExpression() {
         return labelExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRXyzChartSerie.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/dataset/DRXyzChartSerie.java
@@ -39,9 +39,7 @@ public class DRXyzChartSerie extends DRChartSerie implements DRIXyzChartSerie {
     private DRIExpression<?> yValueExpression;
     private DRIExpression<?> zValueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getXValueExpression() {
         return xValueExpression;
@@ -57,9 +55,7 @@ public class DRXyzChartSerie extends DRChartSerie implements DRIXyzChartSerie {
         this.xValueExpression = xValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getYValueExpression() {
         return yValueExpression;
@@ -75,9 +71,7 @@ public class DRXyzChartSerie extends DRChartSerie implements DRIXyzChartSerie {
         this.yValueExpression = yValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getZValueExpression() {
         return zValueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/AbstractBasePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/AbstractBasePlot.java
@@ -60,9 +60,7 @@ public abstract class AbstractBasePlot implements DRIBasePlot {
         this.seriesColorsByName = new HashMap<String, Color>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Orientation getOrientation() {
         return orientation;
@@ -87,9 +85,7 @@ public abstract class AbstractBasePlot implements DRIBasePlot {
         this.seriesColors.add(color);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<Color> getSeriesColors() {
         return seriesColors;
@@ -118,9 +114,7 @@ public abstract class AbstractBasePlot implements DRIBasePlot {
         this.seriesColorsByName.put(seriesName, color);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Map<String, Color> getSeriesColorsByName() {
         return seriesColorsByName;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRAxisFormat.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRAxisFormat.java
@@ -49,9 +49,7 @@ public class DRAxisFormat implements DRIAxisFormat {
     private DRIExpression<? extends Number> rangeMinValueExpression;
     private DRIExpression<? extends Number> rangeMaxValueExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getLabelExpression() {
         return labelExpression;
@@ -66,9 +64,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.labelExpression = labelExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getLabelFont() {
         return labelFont;
@@ -83,9 +79,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.labelFont = labelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLabelColor() {
         return labelColor;
@@ -100,9 +94,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.labelColor = labelColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getTickLabelFont() {
         return tickLabelFont;
@@ -117,9 +109,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.tickLabelFont = tickLabelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getTickLabelColor() {
         return tickLabelColor;
@@ -134,9 +124,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.tickLabelColor = tickLabelColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getTickLabelMask() {
         return tickLabelMask;
@@ -151,9 +139,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.tickLabelMask = tickLabelMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getVerticalTickLabels() {
         return verticalTickLabels;
@@ -168,9 +154,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.verticalTickLabels = verticalTickLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTickLabelRotation() {
         return tickLabelRotation;
@@ -185,9 +169,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.tickLabelRotation = tickLabelRotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLineColor() {
         return lineColor;
@@ -202,9 +184,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.lineColor = lineColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getRangeMinValueExpression() {
         return rangeMinValueExpression;
@@ -219,9 +199,7 @@ public class DRAxisFormat implements DRIAxisFormat {
         this.rangeMinValueExpression = rangeMinValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getRangeMaxValueExpression() {
         return rangeMaxValueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRAxisPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRAxisPlot.java
@@ -46,9 +46,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
     private Comparator<String> seriesOrderBy;
     private OrderType seriesOrderType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
@@ -56,9 +54,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.yAxisFormat = new DRAxisFormat();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRAxisFormat getXAxisFormat() {
         return xAxisFormat;
@@ -74,9 +70,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.xAxisFormat = xAxisFormat;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRAxisFormat getYAxisFormat() {
         return yAxisFormat;
@@ -92,9 +86,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.yAxisFormat = yAxisFormat;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowValues() {
         return showValues;
@@ -109,9 +101,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.showValues = showValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValuePattern() {
         return valuePattern;
@@ -126,9 +116,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.valuePattern = valuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowPercentages() {
         return showPercentages;
@@ -143,9 +131,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.showPercentages = showPercentages;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPercentValuePattern() {
         return percentValuePattern;
@@ -160,9 +146,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.percentValuePattern = percentValuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparator<String> getSeriesOrderBy() {
         return seriesOrderBy;
@@ -177,9 +161,7 @@ public class DRAxisPlot extends AbstractBasePlot implements DRIAxisPlot {
         this.seriesOrderBy = seriesOrderBy;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OrderType getSeriesOrderType() {
         return seriesOrderType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBar3DPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBar3DPlot.java
@@ -37,9 +37,7 @@ public class DRBar3DPlot extends DRAxisPlot implements DRIBar3DPlot {
     private Double yOffset;
     private Boolean showLabels;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getXOffset() {
         return xOffset;
@@ -54,9 +52,7 @@ public class DRBar3DPlot extends DRAxisPlot implements DRIBar3DPlot {
         this.xOffset = xOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getYOffset() {
         return yOffset;
@@ -71,9 +67,7 @@ public class DRBar3DPlot extends DRAxisPlot implements DRIBar3DPlot {
         this.yOffset = yOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLabels() {
         return showLabels;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBarPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBarPlot.java
@@ -37,9 +37,7 @@ public class DRBarPlot extends DRAxisPlot implements DRIBarPlot {
     private Boolean showTickLabels;
     private Boolean showLabels;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLabels() {
         return showLabels;
@@ -54,9 +52,7 @@ public class DRBarPlot extends DRAxisPlot implements DRIBarPlot {
         this.showLabels = showLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowTickLabels() {
         return showTickLabels;
@@ -71,9 +67,7 @@ public class DRBarPlot extends DRAxisPlot implements DRIBarPlot {
         this.showTickLabels = showTickLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowTickMarks() {
         return showTickMarks;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBubblePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRBubblePlot.java
@@ -36,9 +36,7 @@ public class DRBubblePlot extends DRAxisPlot implements DRIBubblePlot {
 
     private ScaleType scaleType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ScaleType getScaleType() {
         return scaleType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRCandlestickPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRCandlestickPlot.java
@@ -35,9 +35,7 @@ public class DRCandlestickPlot extends DRAxisPlot implements DRICandlestickPlot 
 
     private Boolean showVolume;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowVolume() {
         return showVolume;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRChartAxis.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRChartAxis.java
@@ -38,9 +38,7 @@ public class DRChartAxis implements DRIChartAxis {
     private AxisPosition position;
     private DRIChart chart;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public AxisPosition getPosition() {
         return position;
@@ -55,9 +53,7 @@ public class DRChartAxis implements DRIChartAxis {
         this.position = position;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIChart getChart() {
         return chart;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRDifferencePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRDifferencePlot.java
@@ -39,9 +39,7 @@ public class DRDifferencePlot extends DRAxisPlot implements DRIDifferencePlot {
     private Color negativeColor;
     private Boolean showShapes;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getPositiveColor() {
         return positiveColor;
@@ -56,9 +54,7 @@ public class DRDifferencePlot extends DRAxisPlot implements DRIDifferencePlot {
         this.positiveColor = positiveColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getNegativeColor() {
         return negativeColor;
@@ -73,9 +69,7 @@ public class DRDifferencePlot extends DRAxisPlot implements DRIDifferencePlot {
         this.negativeColor = negativeColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowShapes() {
         return showShapes;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRHighLowPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRHighLowPlot.java
@@ -36,9 +36,7 @@ public class DRHighLowPlot extends DRAxisPlot implements DRIHighLowPlot {
     private Boolean showOpenTicks;
     private Boolean showCloseTicks;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowOpenTicks() {
         return showOpenTicks;
@@ -53,9 +51,7 @@ public class DRHighLowPlot extends DRAxisPlot implements DRIHighLowPlot {
         this.showOpenTicks = showOpenTicks;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowCloseTicks() {
         return showCloseTicks;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRLayeredBarPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRLayeredBarPlot.java
@@ -56,9 +56,7 @@ public class DRLayeredBarPlot extends DRBarPlot implements DRILayeredBarPlot {
         this.seriesBarWidths.add(barWidth);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<Double> getSeriesBarWidths() {
         return seriesBarWidths;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRLinePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRLinePlot.java
@@ -36,9 +36,7 @@ public class DRLinePlot extends DRAxisPlot implements DRILinePlot {
     private Boolean showShapes;
     private Boolean showLines;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowShapes() {
         return showShapes;
@@ -53,9 +51,7 @@ public class DRLinePlot extends DRAxisPlot implements DRILinePlot {
         this.showShapes = showShapes;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLines() {
         return showLines;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMeterInterval.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMeterInterval.java
@@ -42,9 +42,7 @@ public class DRMeterInterval implements DRIMeterInterval {
     private DRIExpression<? extends Number> dataRangeLowExpression;
     private DRIExpression<? extends Number> dataRangeHighExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLabel() {
         return label;
@@ -59,9 +57,7 @@ public class DRMeterInterval implements DRIMeterInterval {
         this.label = label;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -76,9 +72,7 @@ public class DRMeterInterval implements DRIMeterInterval {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getAlpha() {
         return alpha;
@@ -93,9 +87,7 @@ public class DRMeterInterval implements DRIMeterInterval {
         this.alpha = alpha;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -110,9 +102,7 @@ public class DRMeterInterval implements DRIMeterInterval {
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeHighExpression() {
         return dataRangeHighExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMeterPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMeterPlot.java
@@ -64,9 +64,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         intervals = new ArrayList<DRIMeterInterval>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -81,9 +79,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeHighExpression() {
         return dataRangeHighExpression;
@@ -98,9 +94,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.dataRangeHighExpression = dataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getValueColor() {
         return valueColor;
@@ -115,9 +109,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.valueColor = valueColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValueMask() {
         return valueMask;
@@ -132,9 +124,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.valueMask = valueMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getValueFont() {
         return valueFont;
@@ -149,9 +139,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.valueFont = valueFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public MeterShape getShape() {
         return shape;
@@ -166,9 +154,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.shape = shape;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIMeterInterval> getIntervals() {
         return intervals;
@@ -193,9 +179,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         intervals.add(interval);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getMeterAngle() {
         return meterAngle;
@@ -210,9 +194,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.meterAngle = meterAngle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getUnits() {
         return units;
@@ -227,9 +209,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.units = units;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getTickInterval() {
         return tickInterval;
@@ -244,9 +224,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.tickInterval = tickInterval;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getMeterBackgroundColor() {
         return meterBackgroundColor;
@@ -261,9 +239,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.meterBackgroundColor = meterBackgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getNeedleColor() {
         return needleColor;
@@ -278,9 +254,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.needleColor = needleColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getTickColor() {
         return tickColor;
@@ -295,9 +269,7 @@ public class DRMeterPlot implements DRIMeterPlot {
         this.tickColor = tickColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getTickLabelFont() {
         return tickLabelFont;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMultiAxisPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRMultiAxisPlot.java
@@ -48,9 +48,7 @@ public class DRMultiAxisPlot extends DRAxisPlot implements DRIMultiAxisPlot {
         axes = new ArrayList<DRIChartAxis>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIChartAxis> getAxes() {
         return axes;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPaintScale.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPaintScale.java
@@ -40,9 +40,7 @@ public class DRPaintScale implements DRIPaintScale {
     private double value;
     private Paint paint;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLabel() {
         return label;
@@ -57,9 +55,7 @@ public class DRPaintScale implements DRIPaintScale {
         this.label = label;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public double getValue() {
         return value;
@@ -74,9 +70,7 @@ public class DRPaintScale implements DRIPaintScale {
         this.value = value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getPaint() {
         return paint;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPie3DPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPie3DPlot.java
@@ -35,9 +35,7 @@ public class DRPie3DPlot extends DRPiePlot implements DRIPie3DPlot {
 
     private Double depthFactor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getDepthFactor() {
         return depthFactor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPiePlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRPiePlot.java
@@ -42,9 +42,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
     private String labelFormat;
     private String legendLabelFormat;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getCircular() {
         return circular;
@@ -59,9 +57,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.circular = circular;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowLabels() {
         return showLabels;
@@ -76,9 +72,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.showLabels = showLabels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowValues() {
         return showValues;
@@ -93,9 +87,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.showValues = showValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValuePattern() {
         return valuePattern;
@@ -110,9 +102,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.valuePattern = valuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowPercentages() {
         return showPercentages;
@@ -127,9 +117,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.showPercentages = showPercentages;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPercentValuePattern() {
         return percentValuePattern;
@@ -144,9 +132,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.percentValuePattern = percentValuePattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLabelFormat() {
         return labelFormat;
@@ -161,9 +147,7 @@ public class DRPiePlot extends AbstractBasePlot implements DRIPiePlot {
         this.labelFormat = labelFormat;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getLegendLabelFormat() {
         return legendLabelFormat;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRSpiderPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRSpiderPlot.java
@@ -52,9 +52,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
     private Double labelGap;
     private Color labelColor;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Double> getMaxValueExpression() {
         return maxValueExpression;
@@ -69,9 +67,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.maxValueExpression = maxValueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SpiderRotation getRotation() {
         return rotation;
@@ -86,9 +82,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.rotation = rotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TableOrder getTableOrder() {
         return tableOrder;
@@ -103,9 +97,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.tableOrder = tableOrder;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getWebFilled() {
         return webFilled;
@@ -120,9 +112,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.webFilled = webFilled;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getStartAngle() {
         return startAngle;
@@ -137,9 +127,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.startAngle = startAngle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getHeadPercent() {
         return headPercent;
@@ -154,9 +142,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.headPercent = headPercent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getInteriorGap() {
         return interiorGap;
@@ -171,9 +157,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.interiorGap = interiorGap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getAxisLineColor() {
         return axisLineColor;
@@ -188,9 +172,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.axisLineColor = axisLineColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getAxisLineWidth() {
         return axisLineWidth;
@@ -205,9 +187,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.axisLineWidth = axisLineWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getLabelFont() {
         return labelFont;
@@ -222,9 +202,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.labelFont = labelFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getLabelGap() {
         return labelGap;
@@ -239,9 +217,7 @@ public class DRSpiderPlot implements DRISpiderPlot {
         this.labelGap = labelGap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLabelColor() {
         return labelColor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRThermometerPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRThermometerPlot.java
@@ -52,9 +52,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
     private DRIExpression<? extends Number> highDataRangeLowExpression;
     private DRIExpression<? extends Number> highDataRangeHighExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeLowExpression() {
         return dataRangeLowExpression;
@@ -69,9 +67,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.dataRangeLowExpression = dataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getDataRangeHighExpression() {
         return dataRangeHighExpression;
@@ -86,9 +82,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.dataRangeHighExpression = dataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getValueColor() {
         return valueColor;
@@ -103,9 +97,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.valueColor = valueColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getValueMask() {
         return valueMask;
@@ -120,9 +112,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.valueMask = valueMask;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIFont getValueFont() {
         return valueFont;
@@ -137,9 +127,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.valueFont = valueFont;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ValueLocation getValueLocation() {
         return valueLocation;
@@ -154,9 +142,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.valueLocation = valueLocation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getMercuryColor() {
         return mercuryColor;
@@ -171,9 +157,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.mercuryColor = mercuryColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getLowDataRangeLowExpression() {
         return lowDataRangeLowExpression;
@@ -188,9 +172,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.lowDataRangeLowExpression = lowDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getLowDataRangeHighExpression() {
         return lowDataRangeHighExpression;
@@ -205,9 +187,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.lowDataRangeHighExpression = lowDataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getMediumDataRangeLowExpression() {
         return mediumDataRangeLowExpression;
@@ -222,9 +202,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.mediumDataRangeLowExpression = mediumDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getMediumDataRangeHighExpression() {
         return mediumDataRangeHighExpression;
@@ -239,9 +217,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.mediumDataRangeHighExpression = mediumDataRangeHighExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getHighDataRangeLowExpression() {
         return highDataRangeLowExpression;
@@ -256,9 +232,7 @@ public class DRThermometerPlot implements DRIThermometerPlot {
         this.highDataRangeLowExpression = highDataRangeLowExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Number> getHighDataRangeHighExpression() {
         return highDataRangeHighExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRWaterfallBarPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRWaterfallBarPlot.java
@@ -40,9 +40,7 @@ public class DRWaterfallBarPlot extends DRBarPlot implements DRIWaterfallBarPlot
     private Paint positiveBarPaint;
     private Paint negativeBarPaint;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getFirstBarPaint() {
         return firstBarPaint;
@@ -57,9 +55,7 @@ public class DRWaterfallBarPlot extends DRBarPlot implements DRIWaterfallBarPlot
         this.firstBarPaint = firstBarPaint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getLastBarPaint() {
         return lastBarPaint;
@@ -74,9 +70,7 @@ public class DRWaterfallBarPlot extends DRBarPlot implements DRIWaterfallBarPlot
         this.lastBarPaint = lastBarPaint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getPositiveBarPaint() {
         return positiveBarPaint;
@@ -91,9 +85,7 @@ public class DRWaterfallBarPlot extends DRBarPlot implements DRIWaterfallBarPlot
         this.positiveBarPaint = positiveBarPaint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getNegativeBarPaint() {
         return negativeBarPaint;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRXyBlockPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRXyBlockPlot.java
@@ -55,9 +55,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         paintScales = new ArrayList<DRIPaintScale>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getBlockWidth() {
         return blockWidth;
@@ -72,9 +70,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.blockWidth = blockWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getBlockHeight() {
         return blockHeight;
@@ -89,9 +85,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.blockHeight = blockHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RectangleAnchor getBlockAnchor() {
         return blockAnchor;
@@ -106,9 +100,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.blockAnchor = blockAnchor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public double getDefaultLowerBound() {
         return defaultLowerBound;
@@ -123,9 +115,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.defaultLowerBound = defaultLowerBound;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public double getDefaultUpperBound() {
         return defaultUpperBound;
@@ -140,9 +130,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.defaultUpperBound = defaultUpperBound;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Paint getDefaultPaint() {
         return defaultPaint;
@@ -158,9 +146,7 @@ public class DRXyBlockPlot extends DRAxisPlot implements DRIXyBlockPlot {
         this.defaultPaint = defaultPaint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPaintScale> getPaintScales() {
         return paintScales;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRXyStepPlot.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/chart/plot/DRXyStepPlot.java
@@ -35,9 +35,7 @@ public class DRXyStepPlot extends DRAxisPlot implements DRIXyStepPlot {
 
     private Double stepPoint;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double getStepPoint() {
         return stepPoint;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRBooleanColumn.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRBooleanColumn.java
@@ -44,17 +44,13 @@ public class DRBooleanColumn extends DRColumn<DRIBooleanField> implements DRIBoo
         super(booleanField);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getComponent().getValueExpression().getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRColumn.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRColumn.java
@@ -74,17 +74,13 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         titlePropertyExpressions = new ArrayList<DRIPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T getComponent() {
         return component;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getTitleExpression() {
         return titleExpression;
@@ -99,9 +95,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleExpression = titleExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTitleStyle() {
         return titleStyle;
@@ -116,9 +110,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleStyle = titleStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTitleHeight() {
         return titleHeight;
@@ -136,9 +128,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleHeight = titleHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getTitleHeightType() {
         return titleHeightType;
@@ -153,9 +143,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleHeightType = titleHeightType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTitleRows() {
         return titleRows;
@@ -173,9 +161,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleRows = titleRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleStretchWithOverflow() {
         return titleStretchWithOverflow;
@@ -190,9 +176,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titleStretchWithOverflow = titleStretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getTitlePropertyExpressions() {
         return titlePropertyExpressions;
@@ -217,9 +201,7 @@ public class DRColumn<T extends DRIComponent> implements DRIColumn<T> {
         this.titlePropertyExpressions.add(propertyExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRValueColumn.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/column/DRValueColumn.java
@@ -46,9 +46,7 @@ public class DRValueColumn<T> extends DRColumn<DRITextField<T>> implements DRIVa
         super(valueField);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPrintRepeatedDetailValues() {
         return printRepeatedDetailValues;
@@ -63,17 +61,13 @@ public class DRValueColumn<T> extends DRColumn<DRITextField<T>> implements DRIVa
         this.printRepeatedDetailValues = printRepeatedDetailValues;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getComponent().getValueExpression().getName();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return getComponent().getValueExpression().getValueClass();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRBooleanField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRBooleanField.java
@@ -46,9 +46,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
     private HorizontalImageAlignment horizontalImageAlignment;
     private HorizontalTextAlignment horizontalTextAlignment;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getValueExpression() {
         return valueExpression;
@@ -64,9 +62,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BooleanComponentType getComponentType() {
         return componentType;
@@ -81,9 +77,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.componentType = componentType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getEmptyWhenNullValue() {
         return emptyWhenNullValue;
@@ -98,9 +92,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.emptyWhenNullValue = emptyWhenNullValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getImageWidth() {
         return imageWidth;
@@ -118,9 +110,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.imageWidth = imageWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getImageHeight() {
         return imageHeight;
@@ -138,9 +128,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.imageHeight = imageHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalImageAlignment getHorizontalImageAlignment() {
         return horizontalImageAlignment;
@@ -155,9 +143,7 @@ public class DRBooleanField extends DRHyperLinkComponent implements DRIBooleanFi
         this.horizontalImageAlignment = horizontalImageAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRBreak.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRBreak.java
@@ -36,9 +36,7 @@ public class DRBreak extends DRComponent implements DRIBreak {
 
     private BreakType breakType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BreakType getType() {
         return breakType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRComponent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRComponent.java
@@ -61,9 +61,7 @@ public abstract class DRComponent implements DRIComponent {
         propertyExpressions = new ArrayList<DRIPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getStyle() {
         return style;
@@ -78,9 +76,7 @@ public abstract class DRComponent implements DRIComponent {
         this.style = style;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getPrintWhenExpression() {
         return printWhenExpression;
@@ -95,9 +91,7 @@ public abstract class DRComponent implements DRIComponent {
         this.printWhenExpression = printWhenExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRemoveLineWhenBlank() {
         return removeLineWhenBlank;
@@ -112,9 +106,7 @@ public abstract class DRComponent implements DRIComponent {
         this.removeLineWhenBlank = removeLineWhenBlank;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getPropertyExpressions() {
         return propertyExpressions;
@@ -139,9 +131,7 @@ public abstract class DRComponent implements DRIComponent {
         this.propertyExpressions.add(propertyExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRTableOfContentsHeading getTableOfContentsHeading() {
         return tableOfContentsHeading;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRCurrentDate.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRCurrentDate.java
@@ -35,9 +35,7 @@ public class DRCurrentDate extends DRFormatField implements DRICurrentDate {
 
     private String pattern;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRDimensionComponent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRDimensionComponent.java
@@ -48,9 +48,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
     private Boolean printWhenDetailOverflows;
     private DRIGroup printWhenGroupChanges;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getWidth() {
         return width;
@@ -68,9 +66,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.width = width;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getHeight() {
         return height;
@@ -88,9 +84,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.height = height;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getWidthType() {
         return widthType;
@@ -105,9 +99,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.widthType = widthType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getHeightType() {
         return heightType;
@@ -122,9 +114,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.heightType = heightType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentPositionType getPositionType() {
         return positionType;
@@ -139,9 +129,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.positionType = positionType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public StretchType getStretchType() {
         return stretchType;
@@ -156,9 +144,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.stretchType = stretchType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPrintInFirstWholeBand() {
         return printInFirstWholeBand;
@@ -173,9 +159,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.printInFirstWholeBand = printInFirstWholeBand;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPrintWhenDetailOverflows() {
         return printWhenDetailOverflows;
@@ -190,9 +174,7 @@ public abstract class DRDimensionComponent extends DRComponent implements DRIDim
         this.printWhenDetailOverflows = printWhenDetailOverflows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIGroup getPrintWhenGroupChanges() {
         return printWhenGroupChanges;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DREllipse.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DREllipse.java
@@ -36,9 +36,7 @@ public class DREllipse extends DRDimensionComponent implements DRIEllipse {
 
     private DRPen pen;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRFormatField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRFormatField.java
@@ -39,9 +39,7 @@ public abstract class DRFormatField extends DRHyperLinkComponent implements DRIF
     private DRIExpression<String> formatExpression;
     private HorizontalTextAlignment horizontalTextAlignment;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getFormatExpression() {
         return formatExpression;
@@ -57,9 +55,7 @@ public abstract class DRFormatField extends DRHyperLinkComponent implements DRIF
         this.formatExpression = formatExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRGenericElement.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRGenericElement.java
@@ -46,6 +46,7 @@ public class DRGenericElement extends DRDimensionComponent implements DRIGeneric
      * <p>Constructor for DRGenericElement.</p>
      *
      * @param namespace a {@link java.lang.String} object.
+     * @param namespace a {@link java.lang.String} object.
      * @param name      a {@link java.lang.String} object.
      */
     public DRGenericElement(String namespace, String name) {
@@ -55,18 +56,14 @@ public class DRGenericElement extends DRDimensionComponent implements DRIGeneric
         genericElementName = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
         parameterExpressions = new ArrayList<DRIParameterExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getGenericElementNamespace() {
         return genericElementNamespace;
@@ -81,9 +78,7 @@ public class DRGenericElement extends DRDimensionComponent implements DRIGeneric
         this.genericElementNamespace = genericElementNamespace;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getGenericElementName() {
         return genericElementName;
@@ -98,9 +93,7 @@ public class DRGenericElement extends DRDimensionComponent implements DRIGeneric
         this.genericElementName = genericElementName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIParameterExpression> getParameterExpressions() {
         return parameterExpressions;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRHyperLinkComponent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRHyperLinkComponent.java
@@ -39,9 +39,7 @@ public abstract class DRHyperLinkComponent extends DRDimensionComponent implemen
     private Integer bookmarkLevel;
     private DRHyperLink hyperLink;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getAnchorNameExpression() {
         return anchorNameExpression;
@@ -56,9 +54,7 @@ public abstract class DRHyperLinkComponent extends DRDimensionComponent implemen
         this.anchorNameExpression = anchorNameExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBookmarkLevel() {
         return bookmarkLevel;
@@ -73,9 +69,7 @@ public abstract class DRHyperLinkComponent extends DRDimensionComponent implemen
         this.bookmarkLevel = bookmarkLevel;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRHyperLink getHyperLink() {
         return hyperLink;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRImage.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRImage.java
@@ -43,9 +43,7 @@ public class DRImage extends DRHyperLinkComponent implements DRIImage {
     private Boolean lazy;
     private HorizontalImageAlignment horizontalImageAlignment;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getImageExpression() {
         return imageExpression;
@@ -61,9 +59,7 @@ public class DRImage extends DRHyperLinkComponent implements DRIImage {
         this.imageExpression = imageExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageScale getImageScale() {
         return imageScale;
@@ -78,9 +74,7 @@ public class DRImage extends DRHyperLinkComponent implements DRIImage {
         this.imageScale = imageScale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUsingCache() {
         return usingCache;
@@ -95,9 +89,7 @@ public class DRImage extends DRHyperLinkComponent implements DRIImage {
         this.usingCache = usingCache;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getLazy() {
         return lazy;
@@ -112,9 +104,7 @@ public class DRImage extends DRHyperLinkComponent implements DRIImage {
         this.lazy = lazy;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalImageAlignment getHorizontalImageAlignment() {
         return horizontalImageAlignment;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRLine.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRLine.java
@@ -38,9 +38,7 @@ public class DRLine extends DRDimensionComponent implements DRILine {
     private LineDirection direction;
     private DRPen pen;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineDirection getDirection() {
         return direction;
@@ -55,9 +53,7 @@ public class DRLine extends DRDimensionComponent implements DRILine {
         this.direction = direction;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRList.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRList.java
@@ -61,18 +61,14 @@ public class DRList extends DRDimensionComponent implements DRIList {
         setType(type);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
         this.listCells = new ArrayList<DRListCell>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRListCell> getListCells() {
         return listCells;
@@ -108,9 +104,7 @@ public class DRList extends DRDimensionComponent implements DRIList {
         listCells.add(new DRListCell(horizontalAlignment, verticalAlignment, component));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ListType getType() {
         return type;
@@ -126,9 +120,7 @@ public class DRList extends DRDimensionComponent implements DRIList {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getGap() {
         return gap;
@@ -146,9 +138,7 @@ public class DRList extends DRDimensionComponent implements DRIList {
         this.gap = gap;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getBackgroundComponent() {
         return backgroundComponent;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRListCell.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRListCell.java
@@ -63,9 +63,7 @@ public class DRListCell implements DRIListCell {
         this.verticalAlignment = verticalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalCellComponentAlignment getHorizontalAlignment() {
         return horizontalAlignment;
@@ -80,9 +78,7 @@ public class DRListCell implements DRIListCell {
         this.horizontalAlignment = horizontalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalCellComponentAlignment getVerticalAlignment() {
         return verticalAlignment;
@@ -97,9 +93,7 @@ public class DRListCell implements DRIListCell {
         this.verticalAlignment = verticalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getComponent() {
         return component;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRMap.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRMap.java
@@ -38,9 +38,7 @@ public class DRMap extends DRDimensionComponent implements DRIMap {
     public DRIExpression<Float> longitudeExpression;
     public DRIExpression<Integer> zoomExpression;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Float> getLatitudeExpression() {
         return latitudeExpression;
@@ -55,9 +53,7 @@ public class DRMap extends DRDimensionComponent implements DRIMap {
         this.latitudeExpression = latitudeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Float> getLongitudeExpression() {
         return longitudeExpression;
@@ -72,9 +68,7 @@ public class DRMap extends DRDimensionComponent implements DRIMap {
         this.longitudeExpression = longitudeExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Integer> getZoomExpression() {
         return zoomExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRMultiPageList.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRMultiPageList.java
@@ -48,9 +48,7 @@ public class DRMultiPageList extends DRDimensionComponent implements DRIMultiPag
         components = new ArrayList<DRIComponent>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIComponent> getComponents() {
         return components;
@@ -74,9 +72,7 @@ public class DRMultiPageList extends DRDimensionComponent implements DRIMultiPag
         components.add(component);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public SplitType getSplitType() {
         return splitType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRPageXofY.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRPageXofY.java
@@ -39,9 +39,7 @@ public class DRPageXofY extends DRFormatField implements DRIPageXofY {
     private Integer pageYWidth;
     private ComponentDimensionType pageYWidthType;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageXWidth() {
         return pageXWidth;
@@ -56,9 +54,7 @@ public class DRPageXofY extends DRFormatField implements DRIPageXofY {
         this.pageXWidth = pageXWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getPageXWidthType() {
         return pageXWidthType;
@@ -73,9 +69,7 @@ public class DRPageXofY extends DRFormatField implements DRIPageXofY {
         this.pageXWidthType = pageXWidthType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getPageYWidth() {
         return pageYWidth;
@@ -90,9 +84,7 @@ public class DRPageXofY extends DRFormatField implements DRIPageXofY {
         this.pageYWidth = pageYWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getPageYWidthType() {
         return pageYWidthType;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRRectangle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRRectangle.java
@@ -37,9 +37,7 @@ public class DRRectangle extends DRDimensionComponent implements DRIRectangle {
     private Integer radius;
     private DRPen pen;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRadius() {
         return radius;
@@ -54,9 +52,7 @@ public class DRRectangle extends DRDimensionComponent implements DRIRectangle {
         this.radius = radius;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getPen() {
         return pen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRSubreport.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRSubreport.java
@@ -44,9 +44,7 @@ public class DRSubreport extends DRDimensionComponent implements DRISubreport {
     private DRIExpression<?> dataSourceExpression;
     private Boolean runToBottom;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getReportExpression() {
         return reportExpression;
@@ -62,9 +60,7 @@ public class DRSubreport extends DRDimensionComponent implements DRISubreport {
         this.reportExpression = reportExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Map<String, Object>> getParametersExpression() {
         return parametersExpression;
@@ -79,9 +75,7 @@ public class DRSubreport extends DRDimensionComponent implements DRISubreport {
         this.parametersExpression = parametersExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Connection> getConnectionExpression() {
         return connectionExpression;
@@ -96,9 +90,7 @@ public class DRSubreport extends DRDimensionComponent implements DRISubreport {
         this.connectionExpression = connectionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getDataSourceExpression() {
         return dataSourceExpression;
@@ -113,9 +105,7 @@ public class DRSubreport extends DRDimensionComponent implements DRISubreport {
         this.dataSourceExpression = dataSourceExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getRunToBottom() {
         return runToBottom;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRTextField.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRTextField.java
@@ -55,9 +55,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
     private Boolean stretchWithOverflow;
     private Boolean printRepeatedValues;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<T> getValueExpression() {
         return valueExpression;
@@ -73,9 +71,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -90,9 +86,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getPatternExpression() {
         return patternExpression;
@@ -107,9 +101,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.patternExpression = patternExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -124,9 +116,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? super T> getValueFormatter() {
         return valueFormatter;
@@ -141,9 +131,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.valueFormatter = valueFormatter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDataType<? super T, T> getDataType() {
         return dataType;
@@ -172,7 +160,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
      * This method is used to define the width of a column. The width is set to the <code>columns</code> multiplied by width of the character <em>m</em> for the font used
      *
      * @param columns the number of columns >= 0
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public void setColumns(Integer columns) {
         if (columns != null) {
@@ -195,7 +183,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
      * This method is used to define the height of a column. The height is set to the <code>rows</code> multiplied by height of the font
      *
      * @param rows the number of rows >= 0
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public void setRows(Integer rows) {
         if (rows != null) {
@@ -204,9 +192,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.rows = rows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Evaluation getEvaluationTime() {
         return evaluationTime;
@@ -221,9 +207,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.evaluationTime = evaluationTime;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRGroup getEvaluationGroup() {
         return evaluationGroup;
@@ -238,9 +222,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.evaluationGroup = evaluationGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Markup getMarkup() {
         return markup;
@@ -255,9 +237,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.markup = markup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStretchWithOverflow() {
         return stretchWithOverflow;
@@ -272,9 +252,7 @@ public class DRTextField<T> extends DRHyperLinkComponent implements DRITextField
         this.stretchWithOverflow = stretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPrintRepeatedValues() {
         return printRepeatedValues;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRXyList.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRXyList.java
@@ -39,18 +39,14 @@ public class DRXyList extends DRDimensionComponent implements DRIXyList {
 
     private List<DRXyListCell> xyListCells;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
         this.xyListCells = new ArrayList<DRXyListCell>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRXyListCell> getXyListCells() {
         return xyListCells;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRXyListCell.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/component/DRXyListCell.java
@@ -54,9 +54,7 @@ public class DRXyListCell implements DRIXyListCell {
         this.component = component;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getX() {
         return x;
@@ -71,9 +69,7 @@ public class DRXyListCell implements DRIXyListCell {
         this.x = x;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getY() {
         return y;
@@ -88,9 +84,7 @@ public class DRXyListCell implements DRIXyListCell {
         this.y = y;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRComponent getComponent() {
         return component;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstab.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstab.java
@@ -69,9 +69,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
     private List<DRICrosstabVariable<?>> variables;
     private List<DRICrosstabMeasure<?>> measures;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
@@ -85,17 +83,13 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         headerCell = new DRCrosstabCellContent();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRCrosstabDataset getDataset() {
         return dataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean isRepeatColumnHeaders() {
         return repeatColumnHeaders;
@@ -110,9 +104,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.repeatColumnHeaders = repeatColumnHeaders;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean isRepeatRowHeaders() {
         return repeatRowHeaders;
@@ -127,9 +119,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.repeatRowHeaders = repeatRowHeaders;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getColumnBreakOffset() {
         return columnBreakOffset;
@@ -144,9 +134,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.columnBreakOffset = columnBreakOffset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getIgnoreWidth() {
         return ignoreWidth;
@@ -161,9 +149,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.ignoreWidth = ignoreWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public RunDirection getRunDirection() {
         return runDirection;
@@ -178,33 +164,25 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.runDirection = runDirection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRCrosstabCellContent getWhenNoDataCell() {
         return whenNoDataCell;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRCrosstabCellContent getHeaderCell() {
         return headerCell;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRICrosstabColumnGroup<?>> getColumnGroups() {
         return columnGroups;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getCellWidth() {
         return cellWidth;
@@ -219,9 +197,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.cellWidth = cellWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getCellHeight() {
         return cellHeight;
@@ -236,9 +212,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.cellHeight = cellHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightOddRows() {
         return highlightOddRows;
@@ -253,9 +227,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.highlightOddRows = highlightOddRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getOddRowStyle() {
         return oddRowStyle;
@@ -270,9 +242,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.oddRowStyle = oddRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHighlightEvenRows() {
         return highlightEvenRows;
@@ -287,9 +257,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.highlightEvenRows = highlightEvenRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRSimpleStyle getEvenRowStyle() {
         return evenRowStyle;
@@ -304,9 +272,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.evenRowStyle = evenRowStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupStyle() {
         return groupStyle;
@@ -321,9 +287,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.groupStyle = groupStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGroupTotalStyle() {
         return groupTotalStyle;
@@ -338,9 +302,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.groupTotalStyle = groupTotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getGrandTotalStyle() {
         return grandTotalStyle;
@@ -355,9 +317,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.grandTotalStyle = grandTotalStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getCellStyle() {
         return cellStyle;
@@ -372,9 +332,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.cellStyle = cellStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getMeasureTitleStyle() {
         return measureTitleStyle;
@@ -399,9 +357,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.columnGroups.add(columnGroup);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRICrosstabRowGroup<?>> getRowGroups() {
         return rowGroups;
@@ -417,9 +373,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.rowGroups.add(rowGroup);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRICrosstabVariable<?>> getVariables() {
         return variables;
@@ -435,9 +389,7 @@ public class DRCrosstab extends DRDimensionComponent implements DRICrosstab {
         this.variables.add(variable);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRICrosstabMeasure<?>> getMeasures() {
         return measures;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabCellContent.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabCellContent.java
@@ -47,9 +47,7 @@ public class DRCrosstabCellContent implements DRICrosstabCellContent {
         this.list = new DRList(ListType.VERTICAL);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRList getList() {
         return list;
@@ -64,9 +62,7 @@ public class DRCrosstabCellContent implements DRICrosstabCellContent {
         list.addComponent(component);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getStyle() {
         return style;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabCellStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabCellStyle.java
@@ -62,9 +62,7 @@ public class DRCrosstabCellStyle implements DRICrosstabCellStyle {
         this.columnGroup = columnGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRICrosstabRowGroup<?> getRowGroup() {
         return rowGroup;
@@ -79,9 +77,7 @@ public class DRCrosstabCellStyle implements DRICrosstabCellStyle {
         this.rowGroup = rowGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRICrosstabColumnGroup<?> getColumnGroup() {
         return columnGroup;
@@ -96,9 +92,7 @@ public class DRCrosstabCellStyle implements DRICrosstabCellStyle {
         this.columnGroup = columnGroup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getStyle() {
         return style;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabColumnGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabColumnGroup.java
@@ -36,9 +36,7 @@ public class DRCrosstabColumnGroup<T> extends DRCrosstabGroup<T> implements DRIC
     private Integer headerHeight;
     private Integer totalHeaderWidth;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getHeaderHeight() {
         return headerHeight;
@@ -53,9 +51,7 @@ public class DRCrosstabColumnGroup<T> extends DRCrosstabGroup<T> implements DRIC
         this.headerHeight = headerHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTotalHeaderWidth() {
         return totalHeaderWidth;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabDataset.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabDataset.java
@@ -37,9 +37,7 @@ public class DRCrosstabDataset implements DRICrosstabDataset {
     private DRDataset subDataset;
     private Boolean dataPreSorted;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRDataset getSubDataset() {
         return subDataset;
@@ -54,9 +52,7 @@ public class DRCrosstabDataset implements DRICrosstabDataset {
         this.subDataset = subDataset;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getDataPreSorted() {
         return dataPreSorted;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabGroup.java
@@ -77,17 +77,13 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         totalHeaderPropertyExpressions = new ArrayList<DRIPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getHeaderPattern() {
         return headerPattern;
@@ -102,9 +98,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerPattern = headerPattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHeaderHorizontalTextAlignment() {
         return headerHorizontalTextAlignment;
@@ -119,9 +113,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerHorizontalTextAlignment = headerHorizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? super T> getHeaderValueFormatter() {
         return headerValueFormatter;
@@ -136,9 +128,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerValueFormatter = headerValueFormatter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getHeaderStretchWithOverflow() {
         return headerStretchWithOverflow;
@@ -153,9 +143,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerStretchWithOverflow = headerStretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRHyperLink getHeaderHyperLink() {
         return headerHyperLink;
@@ -170,9 +158,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerHyperLink = headerHyperLink;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getHeaderStyle() {
         return headerStyle;
@@ -187,9 +173,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerStyle = headerStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getHeaderPropertyExpressions() {
         return headerPropertyExpressions;
@@ -214,9 +198,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.headerPropertyExpressions.add(headerPropertyExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getShowTotal() {
         return showTotal;
@@ -231,9 +213,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.showTotal = showTotal;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabTotalPosition getTotalPosition() {
         return totalPosition;
@@ -248,9 +228,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.totalPosition = totalPosition;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getTotalHeaderExpression() {
         return totalHeaderExpression;
@@ -265,9 +243,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.totalHeaderExpression = totalHeaderExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTotalHeaderStretchWithOverflow() {
         return totalHeaderStretchWithOverflow;
@@ -282,9 +258,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.totalHeaderStretchWithOverflow = totalHeaderStretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTotalHeaderStyle() {
         return totalHeaderStyle;
@@ -299,9 +273,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.totalHeaderStyle = totalHeaderStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getTotalHeaderPropertyExpressions() {
         return totalHeaderPropertyExpressions;
@@ -326,9 +298,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.totalHeaderPropertyExpressions.add(totalHeaderPropertyExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<T> getExpression() {
         return expression;
@@ -344,9 +314,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.expression = expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDataType<? super T, T> getDataType() {
         return dataType;
@@ -361,9 +329,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.dataType = dataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Comparable<?>> getOrderByExpression() {
         return orderByExpression;
@@ -378,9 +344,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.orderByExpression = orderByExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public OrderType getOrderType() {
         return orderType;
@@ -395,9 +359,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.orderType = orderType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<? extends Comparator<?>> getComparatorExpression() {
         return comparatorExpression;
@@ -412,9 +374,7 @@ public abstract class DRCrosstabGroup<T> implements DRICrosstabGroup<T> {
         this.comparatorExpression = comparatorExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return getExpression().getValueClass();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabMeasure.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabMeasure.java
@@ -72,25 +72,19 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         propertyExpressions = new ArrayList<DRIPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getExpression() {
         return expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIDataType<? super T, T> getDataType() {
         return dataType;
@@ -105,9 +99,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.dataType = dataType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -122,9 +114,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -139,9 +129,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? super T> getValueFormatter() {
         return valueFormatter;
@@ -156,9 +144,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.valueFormatter = valueFormatter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStretchWithOverflow() {
         return stretchWithOverflow;
@@ -173,9 +159,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.stretchWithOverflow = stretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRHyperLink getHyperLink() {
         return hyperLink;
@@ -190,9 +174,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.hyperLink = hyperLink;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getPropertyExpressions() {
         return propertyExpressions;
@@ -217,9 +199,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.propertyExpressions.add(propertyExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRICrosstabCellStyle> getStyles() {
         return styles;
@@ -234,9 +214,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.styles = styles;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getTitleExpression() {
         return titleExpression;
@@ -251,9 +229,7 @@ public class DRCrosstabMeasure<T> implements DRICrosstabMeasure<T> {
         this.titleExpression = titleExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTitleStyle() {
         return titleStyle;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabRowGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabRowGroup.java
@@ -36,9 +36,7 @@ public class DRCrosstabRowGroup<T> extends DRCrosstabGroup<T> implements DRICros
     private Integer headerWidth;
     private Integer totalHeaderHeight;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getHeaderWidth() {
         return headerWidth;
@@ -53,9 +51,7 @@ public class DRCrosstabRowGroup<T> extends DRCrosstabGroup<T> implements DRICros
         this.headerWidth = headerWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTotalHeaderHeight() {
         return totalHeaderHeight;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabVariable.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/crosstab/DRCrosstabVariable.java
@@ -57,33 +57,25 @@ public class DRCrosstabVariable<T> implements DRICrosstabVariable<T> {
         this.name = ReportUtils.generateUniqueName("crosstabMeasure");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Calculation getCalculation() {
         return calculation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public CrosstabPercentageType getPercentageType() {
         return percentageType;
@@ -98,9 +90,7 @@ public class DRCrosstabVariable<T> implements DRICrosstabVariable<T> {
         this.percentageType = percentageType;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<? super T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/datatype/AbstractDataType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/datatype/AbstractDataType.java
@@ -41,33 +41,25 @@ import java.util.Locale;
 public abstract class AbstractDataType<U, T extends U> implements DRIDataType<U, T> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? extends U> getValueFormatter() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String valueToString(U value, Locale locale) {
         if (value != null) {
@@ -76,50 +68,38 @@ public abstract class AbstractDataType<U, T extends U> implements DRIDataType<U,
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String valueToString(DRIValue<? extends U> value, ReportParameters reportParameters) {
         return valueToString(reportParameters.getValue(value), reportParameters.getLocale());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public String valueToString(String name, ReportParameters reportParameters) {
         return valueToString((U) reportParameters.getValue(name), reportParameters.getLocale());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T stringToValue(String value, Locale locale) throws DRException {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T stringToValue(DRIValue<String> value, ReportParameters reportParameters) throws DRException {
         return stringToValue(reportParameters.getValue(value), reportParameters.getLocale());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T stringToValue(String name, ReportParameters reportParameters) throws DRException {
         return stringToValue((String) reportParameters.getValue(name), reportParameters.getLocale());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/datatype/DRDataType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/datatype/DRDataType.java
@@ -64,9 +64,7 @@ public class DRDataType<U, T extends U> extends AbstractDataType<U, T> {
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -81,9 +79,7 @@ public class DRDataType<U, T extends U> extends AbstractDataType<U, T> {
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -98,9 +94,7 @@ public class DRDataType<U, T extends U> extends AbstractDataType<U, T> {
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? extends U> getValueFormatter() {
         return valueFormatter;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractSimpleExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractSimpleExpression.java
@@ -54,17 +54,13 @@ public abstract class AbstractSimpleExpression<T> implements DRISimpleExpression
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<? super T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractSystemExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractSystemExpression.java
@@ -47,17 +47,13 @@ public abstract class AbstractSystemExpression<T> implements DRISystemExpression
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<? super T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractValueFormatter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/expression/AbstractValueFormatter.java
@@ -63,9 +63,7 @@ public abstract class AbstractValueFormatter<T, U> implements DRIValueFormatter<
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGrid.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGrid.java
@@ -53,9 +53,7 @@ public class DRColumnGrid implements DRIColumnGrid {
         this.list = new DRColumnGridList(type);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRColumnGridList getList() {
         return list;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGridList.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGridList.java
@@ -62,9 +62,7 @@ public class DRColumnGridList implements DRIColumnGridList {
         this.listCells = new ArrayList<DRColumnGridListCell>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRColumnGridListCell> getListCells() {
         return listCells;
@@ -100,9 +98,7 @@ public class DRColumnGridList implements DRIColumnGridList {
         listCells.add(new DRColumnGridListCell(horizontalAlignment, verticalAlignment, component));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ListType getType() {
         return type;
@@ -118,9 +114,7 @@ public class DRColumnGridList implements DRIColumnGridList {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getGap() {
         return gap;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGridListCell.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnGridListCell.java
@@ -64,9 +64,7 @@ public class DRColumnGridListCell implements DRIColumnGridListCell {
         this.verticalAlignment = verticalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalCellComponentAlignment getHorizontalAlignment() {
         return horizontalAlignment;
@@ -81,9 +79,7 @@ public class DRColumnGridListCell implements DRIColumnGridListCell {
         this.horizontalAlignment = horizontalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalCellComponentAlignment getVerticalAlignment() {
         return verticalAlignment;
@@ -98,9 +94,7 @@ public class DRColumnGridListCell implements DRIColumnGridListCell {
         this.verticalAlignment = verticalAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIColumnGridComponent getComponent() {
         return component;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnTitleGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/grid/DRColumnTitleGroup.java
@@ -64,9 +64,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         titlePropertyExpressions = new ArrayList<DRIPropertyExpression>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRColumnGridList getList() {
         return list;
@@ -81,9 +79,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         list.addComponent(component);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getTitleExpression() {
         return titleExpression;
@@ -98,9 +94,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         this.titleExpression = titleExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getTitleStyle() {
         return titleStyle;
@@ -129,7 +123,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
      * Sets the column title width.
      *
      * @param titleWidth the column title width >= 0
-     * @throws IllegalArgumentException if <code>titleWidth</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>titleWidth</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public void setTitleWidth(Integer titleWidth) {
@@ -139,9 +133,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         this.titleWidth = titleWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getTitleWidthType() {
         return titleWidthType;
@@ -170,7 +162,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
      * This method is used to define the width of a column title. The width is set to the <code>columns</code> multiplied by width of the character <em>m</em> for the font used
      *
      * @param titleColumns the number of columns >= 0
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public void setTitleColumns(Integer titleColumns) {
         if (titleColumns != null) {
@@ -193,7 +185,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
      * Sets the column title height.
      *
      * @param titleHeight the column title height >= 0
-     * @throws IllegalArgumentException if <code>titleHeight</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>titleHeight</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public void setTitleHeight(Integer titleHeight) {
@@ -203,9 +195,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         this.titleHeight = titleHeight;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ComponentDimensionType getTitleHeightType() {
         return titleHeightType;
@@ -234,7 +224,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
      * This method is used to define the height of a column title. The height is set to the <code>rows</code> multiplied by height of the font
      *
      * @param titleRows the number of rows >= 0
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public void setTitleRows(Integer titleRows) {
         if (titleRows != null) {
@@ -243,9 +233,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         this.titleRows = titleRows;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getTitleStretchWithOverflow() {
         return titleStretchWithOverflow;
@@ -260,9 +248,7 @@ public class DRColumnTitleGroup implements DRIColumnTitleGroup {
         this.titleStretchWithOverflow = titleStretchWithOverflow;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIPropertyExpression> getTitlePropertyExpressions() {
         return titlePropertyExpressions;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRBaseStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRBaseStyle.java
@@ -77,9 +77,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         linePen = new DRPen();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getForegroundColor() {
         return foregroundColor;
@@ -94,9 +92,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.foregroundColor = foregroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getBackgroundColor() {
         return backgroundColor;
@@ -111,9 +107,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.backgroundColor = backgroundColor;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRadius() {
         return radius;
@@ -128,9 +122,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.radius = radius;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public ImageScale getImageScale() {
         return imageScale;
@@ -145,9 +137,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.imageScale = imageScale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalImageAlignment getHorizontalImageAlignment() {
         return horizontalImageAlignment;
@@ -162,9 +152,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.horizontalImageAlignment = horizontalImageAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalImageAlignment getVerticalImageAlignment() {
         return verticalImageAlignment;
@@ -179,9 +167,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.verticalImageAlignment = verticalImageAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return horizontalTextAlignment;
@@ -196,9 +182,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.horizontalTextAlignment = horizontalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public VerticalTextAlignment getVerticalTextAlignment() {
         return verticalTextAlignment;
@@ -213,9 +197,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.verticalTextAlignment = verticalTextAlignment;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRBorder getBorder() {
         return border;
@@ -230,9 +212,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.border = border;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPadding getPadding() {
         return padding;
@@ -247,9 +227,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.padding = padding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRFont getFont() {
         return font;
@@ -264,9 +242,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.font = font;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Rotation getRotation() {
         return rotation;
@@ -281,9 +257,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.rotation = rotation;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return pattern;
@@ -298,9 +272,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.pattern = pattern;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Markup getMarkup() {
         return markup;
@@ -315,9 +287,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.markup = markup;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRParagraph getParagraph() {
         return paragraph;
@@ -332,9 +302,7 @@ public abstract class DRBaseStyle implements DRIBaseStyle {
         this.paragraph = paragraph;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getLinePen() {
         return linePen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRBorder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRBorder.java
@@ -60,9 +60,7 @@ public class DRBorder implements DRIBorder {
         rightPen = pen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getTopPen() {
         return topPen;
@@ -77,9 +75,7 @@ public class DRBorder implements DRIBorder {
         this.topPen = topPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getLeftPen() {
         return leftPen;
@@ -94,9 +90,7 @@ public class DRBorder implements DRIBorder {
         this.leftPen = leftPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getBottomPen() {
         return bottomPen;
@@ -111,9 +105,7 @@ public class DRBorder implements DRIBorder {
         this.bottomPen = bottomPen;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRPen getRightPen() {
         return rightPen;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRConditionalStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRConditionalStyle.java
@@ -47,9 +47,7 @@ public class DRConditionalStyle extends DRBaseStyle implements DRIConditionalSty
         this.conditionExpression = conditionExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<Boolean> getConditionExpression() {
         return conditionExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRFont.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRFont.java
@@ -76,9 +76,7 @@ public class DRFont implements DRIFont {
         this.setFontSize(fontSize);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getFontName() {
         return fontName;
@@ -93,9 +91,7 @@ public class DRFont implements DRIFont {
         this.fontName = fontName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getBold() {
         return bold;
@@ -110,9 +106,7 @@ public class DRFont implements DRIFont {
         this.bold = bold;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getItalic() {
         return italic;
@@ -127,9 +121,7 @@ public class DRFont implements DRIFont {
         this.italic = italic;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getUnderline() {
         return underline;
@@ -144,9 +136,7 @@ public class DRFont implements DRIFont {
         this.underline = underline;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getStrikeThrough() {
         return strikeThrough;
@@ -161,9 +151,7 @@ public class DRFont implements DRIFont {
         this.strikeThrough = strikeThrough;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFontSize() {
         return fontSize;
@@ -181,9 +169,7 @@ public class DRFont implements DRIFont {
         this.fontSize = fontSize;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPdfFontName() {
         return pdfFontName;
@@ -199,9 +185,7 @@ public class DRFont implements DRIFont {
         this.pdfFontName = pdfFontName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPdfEncoding() {
         return pdfEncoding;
@@ -217,9 +201,7 @@ public class DRFont implements DRIFont {
         this.pdfEncoding = pdfEncoding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean getPdfEmbedded() {
         return pdfEmbedded;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRPadding.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRPadding.java
@@ -60,9 +60,7 @@ public class DRPadding implements DRIPadding {
         right = padding;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTop() {
         return top;
@@ -80,9 +78,7 @@ public class DRPadding implements DRIPadding {
         this.top = top;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getLeft() {
         return left;
@@ -100,9 +96,7 @@ public class DRPadding implements DRIPadding {
         this.left = left;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getBottom() {
         return bottom;
@@ -120,9 +114,7 @@ public class DRPadding implements DRIPadding {
         this.bottom = bottom;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRight() {
         return right;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRParagraph.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRParagraph.java
@@ -55,9 +55,7 @@ public class DRParagraph implements DRIParagraph {
         tabStops = new ArrayList<DRITabStop>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineSpacing getLineSpacing() {
         return lineSpacing;
@@ -72,9 +70,7 @@ public class DRParagraph implements DRIParagraph {
         this.lineSpacing = lineSpacing;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getLineSpacingSize() {
         return lineSpacingSize;
@@ -89,9 +85,7 @@ public class DRParagraph implements DRIParagraph {
         this.lineSpacingSize = lineSpacingSize;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getFirstLineIndent() {
         return firstLineIndent;
@@ -106,9 +100,7 @@ public class DRParagraph implements DRIParagraph {
         this.firstLineIndent = firstLineIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getLeftIndent() {
         return leftIndent;
@@ -123,9 +115,7 @@ public class DRParagraph implements DRIParagraph {
         this.leftIndent = leftIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getRightIndent() {
         return rightIndent;
@@ -140,9 +130,7 @@ public class DRParagraph implements DRIParagraph {
         this.rightIndent = rightIndent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSpacingBefore() {
         return spacingBefore;
@@ -157,9 +145,7 @@ public class DRParagraph implements DRIParagraph {
         this.spacingBefore = spacingBefore;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getSpacingAfter() {
         return spacingAfter;
@@ -174,9 +160,7 @@ public class DRParagraph implements DRIParagraph {
         this.spacingAfter = spacingAfter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer getTabStopWidth() {
         return tabStopWidth;
@@ -191,9 +175,7 @@ public class DRParagraph implements DRIParagraph {
         this.tabStopWidth = tabStopWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRITabStop> getTabStops() {
         return tabStops;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRPen.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRPen.java
@@ -58,9 +58,7 @@ public class DRPen implements DRIPen {
         this.lineStyle = lineStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Float getLineWidth() {
         return lineWidth;
@@ -78,9 +76,7 @@ public class DRPen implements DRIPen {
         this.lineWidth = lineWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public LineStyle getLineStyle() {
         return lineStyle;
@@ -95,9 +91,7 @@ public class DRPen implements DRIPen {
         this.lineStyle = lineStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Color getLineColor() {
         return lineColor;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRStyle.java
@@ -42,18 +42,14 @@ public class DRStyle extends DRBaseStyle implements DRIStyle {
     private DRIReportStyle parentStyle;
     private List<DRConditionalStyle> conditionalStyles;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         super.init();
         conditionalStyles = new ArrayList<DRConditionalStyle>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -68,9 +64,7 @@ public class DRStyle extends DRBaseStyle implements DRIStyle {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIReportStyle getParentStyle() {
         return parentStyle;
@@ -85,9 +79,7 @@ public class DRStyle extends DRBaseStyle implements DRIStyle {
         this.parentStyle = parentStyle;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRConditionalStyle> getConditionalStyles() {
         return conditionalStyles;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRTabStop.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRTabStop.java
@@ -37,9 +37,7 @@ public class DRTabStop implements DRITabStop {
     private int position;
     private TabStopAlignment alignment;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int getPosition() {
         return position;
@@ -54,9 +52,7 @@ public class DRTabStop implements DRITabStop {
         this.position = position;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TabStopAlignment getAlignment() {
         return alignment;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRTemplateStyle.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/base/style/DRTemplateStyle.java
@@ -44,9 +44,7 @@ public class DRTemplateStyle implements DRITemplateStyle {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/FieldBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/FieldBuilder.java
@@ -76,9 +76,7 @@ public class FieldBuilder<T> extends AbstractBuilder<FieldBuilder<T>, DRField<T>
         return build();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getField().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/ReportBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/ReportBuilder.java
@@ -72,205 +72,93 @@ import java.util.ResourceBundle;
 public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T, DRReport> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * <p>Constructor for ReportBuilder.</p>
-     */
     public ReportBuilder() {
         super(new DRReport());
     }
 
-    /**
-     * <p>setReportName.</p>
-     *
-     * @param reportName a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T setReportName(String reportName) {
         getObject().setReportName(reportName);
         return (T) this;
     }
 
-    /**
-     * <p>setLocale.</p>
-     *
-     * @param locale a {@link java.util.Locale} object.
-     * @return a T object.
-     */
     public T setLocale(Locale locale) {
         getObject().setLocale(locale);
         return (T) this;
     }
 
-    /**
-     * <p>setResourceBundle.</p>
-     *
-     * @param resourceBundle a {@link java.util.ResourceBundle} object.
-     * @return a T object.
-     */
     public T setResourceBundle(ResourceBundle resourceBundle) {
         getObject().setResourceBundle(resourceBundle);
         return (T) this;
     }
 
-    /**
-     * <p>setResourceBundle.</p>
-     *
-     * @param resourceBundleName a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T setResourceBundle(String resourceBundleName) {
         getObject().setResourceBundleName(resourceBundleName);
         return (T) this;
     }
 
-    /**
-     * <p>setShowColumnTitle.</p>
-     *
-     * @param showColumnTitle a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setShowColumnTitle(Boolean showColumnTitle) {
         getObject().setShowColumnTitle(showColumnTitle);
         return (T) this;
     }
 
-    /**
-     * <p>setShowColumnValues.</p>
-     *
-     * @param showColumnValues a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setShowColumnValues(Boolean showColumnValues) {
         getObject().setShowColumnValues(showColumnValues);
         return (T) this;
     }
 
-    /**
-     * <p>setPageFormat.</p>
-     *
-     * @param pageType a {@link net.sf.dynamicreports.report.constant.PageType} object.
-     * @return a T object.
-     */
     public T setPageFormat(PageType pageType) {
         return setPageFormat(pageType, PageOrientation.PORTRAIT);
     }
 
-    /**
-     * <p>setPageFormat.</p>
-     *
-     * @param pageType    a {@link net.sf.dynamicreports.report.constant.PageType} object.
-     * @param orientation a {@link net.sf.dynamicreports.report.constant.PageOrientation} object.
-     * @return a T object.
-     */
     public T setPageFormat(PageType pageType, PageOrientation orientation) {
         getObject().getPage().setPageFormat(pageType, orientation);
         return (T) this;
     }
 
-    /**
-     * <p>setPageFormat.</p>
-     *
-     * @param width       a {@link java.lang.Integer} object.
-     * @param height      a {@link java.lang.Integer} object.
-     * @param orientation a {@link net.sf.dynamicreports.report.constant.PageOrientation} object.
-     * @return a T object.
-     */
     public T setPageFormat(Integer width, Integer height, PageOrientation orientation) {
         getObject().getPage().setPageFormat(width, height, orientation);
         return (T) this;
     }
 
-    /**
-     * <p>setPageMargin.</p>
-     *
-     * @param margin a {@link net.sf.dynamicreports.report.builder.MarginBuilder} object.
-     * @return a T object.
-     */
     public T setPageMargin(MarginBuilder margin) {
         Validate.notNull(margin, "margin must not be null");
         getObject().getPage().setMargin(margin.build());
         return (T) this;
     }
 
-    /**
-     * <p>setPageColumnsPerPage.</p>
-     *
-     * @param columnsPerPage a {@link java.lang.Integer} object.
-     * @return a T object.
-     */
     public T setPageColumnsPerPage(Integer columnsPerPage) {
         getObject().getPage().setColumnsPerPage(columnsPerPage);
         return (T) this;
     }
 
-    /**
-     * <p>setPageColumnSpace.</p>
-     *
-     * @param columnSpace a {@link java.lang.Integer} object.
-     * @return a T object.
-     */
     public T setPageColumnSpace(Integer columnSpace) {
         getObject().getPage().setColumnSpace(columnSpace);
         return (T) this;
     }
 
-    /**
-     * <p>ignorePageWidth.</p>
-     *
-     * @return a T object.
-     */
     public T ignorePageWidth() {
         return setIgnorePageWidth(true);
     }
 
-    /**
-     * <p>setIgnorePageWidth.</p>
-     *
-     * @param ignorePageWidth a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setIgnorePageWidth(Boolean ignorePageWidth) {
         getObject().getPage().setIgnorePageWidth(ignorePageWidth);
         return (T) this;
     }
 
-    /**
-     * <p>ignorePagination.</p>
-     *
-     * @return a T object.
-     */
     public T ignorePagination() {
         return setIgnorePagination(true);
     }
 
-    /**
-     * <p>setIgnorePagination.</p>
-     *
-     * @param ignorePagination a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setIgnorePagination(Boolean ignorePagination) {
         getObject().setIgnorePagination(ignorePagination);
         return (T) this;
     }
 
-    /**
-     * <p>setWhenNoDataType.</p>
-     *
-     * @param whenNoDataType a {@link net.sf.dynamicreports.report.constant.WhenNoDataType} object.
-     * @return a T object.
-     */
     public T setWhenNoDataType(WhenNoDataType whenNoDataType) {
         getObject().setWhenNoDataType(whenNoDataType);
         return (T) this;
     }
 
-    /**
-     * <p>setWhenResourceMissingType.</p>
-     *
-     * @param whenResourceMissingType a {@link net.sf.dynamicreports.report.constant.WhenResourceMissingType} object.
-     * @return a T object.
-     */
     public T setWhenResourceMissingType(WhenResourceMissingType whenResourceMissingType) {
         getObject().setWhenResourceMissingType(whenResourceMissingType);
         return (T) this;
@@ -356,66 +244,30 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setPrintOrder.</p>
-     *
-     * @param printOrder a {@link net.sf.dynamicreports.report.constant.Orientation} object.
-     * @return a T object.
-     */
     public T setPrintOrder(Orientation printOrder) {
         getObject().setPrintOrder(printOrder);
         return (T) this;
     }
 
-    /**
-     * <p>setColumnDirection.</p>
-     *
-     * @param columnDirection a {@link net.sf.dynamicreports.report.constant.RunDirection} object.
-     * @return a T object.
-     */
     public T setColumnDirection(RunDirection columnDirection) {
         getObject().setColumnDirection(columnDirection);
         return (T) this;
     }
 
-    /**
-     * <p>setLanguage.</p>
-     *
-     * @param language a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T setLanguage(String language) {
         getObject().setLanguage(language);
         return (T) this;
     }
 
-    /**
-     * <p>setUseFieldNameAsDescription.</p>
-     *
-     * @param useFieldNameAsDescription a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setUseFieldNameAsDescription(Boolean useFieldNameAsDescription) {
         getObject().setUseFieldNameAsDescription(useFieldNameAsDescription);
         return (T) this;
     }
 
-    /**
-     * <p>scriptlets.</p>
-     *
-     * @param scriptlets a {@link net.sf.dynamicreports.report.definition.DRIScriptlet} object.
-     * @return a T object.
-     */
     public T scriptlets(DRIScriptlet... scriptlets) {
         return addScriptlet(scriptlets);
     }
 
-    /**
-     * <p>addScriptlet.</p>
-     *
-     * @param scriptlets a {@link net.sf.dynamicreports.report.definition.DRIScriptlet} object.
-     * @return a T object.
-     */
     public T addScriptlet(DRIScriptlet... scriptlets) {
         Validate.notNull(scriptlets, "scriptlets must not be null");
         Validate.noNullElements(scriptlets, "scriptlets must not contains null scriptlet");
@@ -425,93 +277,42 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setProperties.</p>
-     *
-     * @param properties a {@link java.util.Properties} object.
-     * @return a T object.
-     */
     public T setProperties(Properties properties) {
         getObject().setProperties(properties);
         return (T) this;
     }
 
-    /**
-     * <p>addProperty.</p>
-     *
-     * @param key   a {@link java.lang.String} object.
-     * @param value a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T addProperty(String key, String value) {
         getObject().addProperty(key, value);
         return (T) this;
     }
 
-    /**
-     * <p>setQuery.</p>
-     *
-     * @param text     a {@link java.lang.String} object.
-     * @param language a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T setQuery(String text, String language) {
         Validate.notNull(text, "text must not be null");
         Validate.notNull(language, "language must not be null");
         return setQuery(DynamicReports.query(text, language));
     }
 
-    /**
-     * <p>setQuery.</p>
-     *
-     * @param sql a {@link java.lang.String} object.
-     * @return a T object.
-     */
     public T setQuery(String sql) {
         Validate.notNull(sql, "sql must not be null");
         return setQuery(DynamicReports.query(sql, QueryLanguage.SQL));
     }
 
-    /**
-     * <p>setQuery.</p>
-     *
-     * @param query a {@link net.sf.dynamicreports.report.builder.QueryBuilder} object.
-     * @return a T object.
-     */
     public T setQuery(QueryBuilder query) {
         Validate.notNull(query, "query must not be null");
         getObject().setQuery(query.build());
         return (T) this;
     }
 
-    /**
-     * <p>columnGrid.</p>
-     *
-     * @param type a {@link net.sf.dynamicreports.report.constant.ListType} object.
-     * @return a T object.
-     */
     public T columnGrid(ListType type) {
         getObject().setColumnGrid(new DRColumnGrid(type));
         return (T) this;
     }
 
-    /**
-     * <p>columnGrid.</p>
-     *
-     * @param components a {@link net.sf.dynamicreports.report.builder.grid.ColumnGridComponentBuilder} object.
-     * @return a T object.
-     */
     public T columnGrid(ColumnGridComponentBuilder... components) {
         return columnGrid(ListType.HORIZONTAL, components);
     }
 
-    /**
-     * <p>columnGrid.</p>
-     *
-     * @param type       a {@link net.sf.dynamicreports.report.constant.ListType} object.
-     * @param components a {@link net.sf.dynamicreports.report.builder.grid.ColumnGridComponentBuilder} object.
-     * @return a T object.
-     */
     public T columnGrid(ListType type, ColumnGridComponentBuilder... components) {
         Validate.notNull(components, "components must not be null");
         Validate.noNullElements(components, "components must not contains null component");
@@ -524,13 +325,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // template
-
-    /**
-     * <p>setTemplate.</p>
-     *
-     * @param template a {@link net.sf.dynamicreports.report.builder.ReportTemplateBuilder} object.
-     * @return a T object.
-     */
     public T setTemplate(ReportTemplateBuilder template) {
         Validate.notNull(template, "template must not be null");
         getObject().setTemplate(template.build());
@@ -538,23 +332,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // template style
-
-    /**
-     * <p>templateStyles.</p>
-     *
-     * @param templateStyles a {@link net.sf.dynamicreports.report.builder.style.TemplateStylesBuilder} object.
-     * @return a T object.
-     */
     public T templateStyles(TemplateStylesBuilder... templateStyles) {
         return addTemplateStyle(templateStyles);
     }
 
-    /**
-     * <p>addTemplateStyle.</p>
-     *
-     * @param templateStyles a {@link net.sf.dynamicreports.report.builder.style.TemplateStylesBuilder} object.
-     * @return a T object.
-     */
     public T addTemplateStyle(TemplateStylesBuilder... templateStyles) {
         Validate.notNull(templateStyles, "templateStyles must not be null");
         Validate.noNullElements(templateStyles, "templateStyles must not contains null templateStyle");
@@ -566,22 +347,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>templateStyles.</p>
-     *
-     * @param templateStyles a {@link net.sf.dynamicreports.report.builder.style.StyleBuilder} object.
-     * @return a T object.
-     */
     public T templateStyles(StyleBuilder... templateStyles) {
         return addTemplateStyle(templateStyles);
     }
 
-    /**
-     * <p>addTemplateStyle.</p>
-     *
-     * @param templateStyles a {@link net.sf.dynamicreports.report.builder.style.StyleBuilder} object.
-     * @return a T object.
-     */
     public T addTemplateStyle(StyleBuilder... templateStyles) {
         Validate.notNull(templateStyles, "templateStyles must not be null");
         Validate.noNullElements(templateStyles, "templateStyles must not contains null templateStyle");
@@ -592,45 +361,18 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // parameter
-
-    /**
-     * <p>parameters.</p>
-     *
-     * @param parameters a {@link net.sf.dynamicreports.report.builder.ParameterBuilder} object.
-     * @return a T object.
-     */
     public T parameters(ParameterBuilder<?>... parameters) {
         return addParameter(parameters);
     }
 
-    /**
-     * <p>addParameter.</p>
-     *
-     * @param name  a {@link java.lang.String} object.
-     * @param value a {@link java.lang.Object} object.
-     * @return a T object.
-     */
     public T addParameter(String name, Object value) {
         return addParameter(DynamicReports.parameter(name, value));
     }
 
-    /**
-     * <p>addParameter.</p>
-     *
-     * @param name       a {@link java.lang.String} object.
-     * @param valueClass a {@link java.lang.Class} object.
-     * @return a T object.
-     */
     public T addParameter(String name, Class<?> valueClass) {
         return addParameter(DynamicReports.parameter(name, valueClass));
     }
 
-    /**
-     * <p>addParameter.</p>
-     *
-     * @param parameters a {@link net.sf.dynamicreports.report.builder.ParameterBuilder} object.
-     * @return a T object.
-     */
     public T addParameter(ParameterBuilder<?>... parameters) {
         Validate.notNull(parameters, "parameters must not be null");
         Validate.noNullElements(parameters, "parameters must not contains null parameter");
@@ -640,70 +382,29 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setParameter.</p>
-     *
-     * @param name  a {@link java.lang.String} object.
-     * @param value a {@link java.lang.Object} object.
-     * @return a T object.
-     */
     public T setParameter(String name, Object value) {
         getObject().addParameterValue(name, value);
         return (T) this;
     }
 
-    /**
-     * <p>setParameters.</p>
-     *
-     * @param parameters a {@link java.util.Map} object.
-     * @return a T object.
-     */
     public T setParameters(Map<String, Object> parameters) {
         getObject().setParameterValues(parameters);
         return (T) this;
     }
 
     // field
-
-    /**
-     * <p>fields.</p>
-     *
-     * @param fields a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @return a T object.
-     */
     public T fields(FieldBuilder<?>... fields) {
         return addField(fields);
     }
 
-    /**
-     * <p>addField.</p>
-     *
-     * @param name       a {@link java.lang.String} object.
-     * @param valueClass a {@link java.lang.Class} object.
-     * @return a T object.
-     */
     public T addField(String name, Class<?> valueClass) {
         return addField(DynamicReports.field(name, valueClass));
     }
 
-    /**
-     * <p>addField.</p>
-     *
-     * @param name     a {@link java.lang.String} object.
-     * @param dataType a {@link net.sf.dynamicreports.report.definition.datatype.DRIDataType} object.
-     * @param <U>      a U object.
-     * @return a T object.
-     */
     public <U> T addField(String name, DRIDataType<? super U, U> dataType) {
         return addField(DynamicReports.field(name, dataType));
     }
 
-    /**
-     * <p>addField.</p>
-     *
-     * @param fields a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @return a T object.
-     */
     public T addField(FieldBuilder<?>... fields) {
         Validate.notNull(fields, "fields must not be null");
         Validate.noNullElements(fields, "fields must not contains null field");
@@ -714,23 +415,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // variable
-
-    /**
-     * <p>variables.</p>
-     *
-     * @param variables a {@link net.sf.dynamicreports.report.builder.VariableBuilder} object.
-     * @return a T object.
-     */
     public T variables(VariableBuilder<?>... variables) {
         return addVariable(variables);
     }
 
-    /**
-     * <p>addVariable.</p>
-     *
-     * @param variables a {@link net.sf.dynamicreports.report.builder.VariableBuilder} object.
-     * @return a T object.
-     */
     public T addVariable(VariableBuilder<?>... variables) {
         Validate.notNull(variables, "variables must not be null");
         Validate.noNullElements(variables, "variables must not contains null variable");
@@ -781,23 +469,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // column
-
-    /**
-     * <p>columns.</p>
-     *
-     * @param columns a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a T object.
-     */
     public T columns(ColumnBuilder<?, ?>... columns) {
         return addColumn(columns);
     }
 
-    /**
-     * <p>addColumn.</p>
-     *
-     * @param columns a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a T object.
-     */
     public T addColumn(ColumnBuilder<?, ?>... columns) {
         Validate.notNull(columns, "columns must not be null");
         Validate.noNullElements(columns, "columns must not contains null column");
@@ -808,13 +483,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // style
-
-    /**
-     * <p>setDefaultFont.</p>
-     *
-     * @param defaultFont a {@link net.sf.dynamicreports.report.builder.style.FontBuilder} object.
-     * @return a T object.
-     */
     public T setDefaultFont(FontBuilder defaultFont) {
         if (defaultFont != null) {
             getObject().setDefaultFont(defaultFont.build());
@@ -824,12 +492,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setTextStyle.</p>
-     *
-     * @param textStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setTextStyle(ReportStyleBuilder textStyle) {
         if (textStyle != null) {
             getObject().setTextStyle(textStyle.build());
@@ -839,12 +501,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnTitleStyle.</p>
-     *
-     * @param columnTitleStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setColumnTitleStyle(ReportStyleBuilder columnTitleStyle) {
         if (columnTitleStyle != null) {
             getObject().setColumnTitleStyle(columnTitleStyle.build());
@@ -854,12 +510,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnStyle.</p>
-     *
-     * @param columnStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setColumnStyle(ReportStyleBuilder columnStyle) {
         if (columnStyle != null) {
             getObject().setColumnStyle(columnStyle.build());
@@ -869,12 +519,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupTitleStyle.</p>
-     *
-     * @param groupTitleStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setGroupTitleStyle(ReportStyleBuilder groupTitleStyle) {
         if (groupTitleStyle != null) {
             getObject().setGroupTitleStyle(groupTitleStyle.build());
@@ -884,12 +528,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupStyle.</p>
-     *
-     * @param groupStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setGroupStyle(ReportStyleBuilder groupStyle) {
         if (groupStyle != null) {
             getObject().setGroupStyle(groupStyle.build());
@@ -899,12 +537,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setSubtotalStyle.</p>
-     *
-     * @param subtotalStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setSubtotalStyle(ReportStyleBuilder subtotalStyle) {
         if (subtotalStyle != null) {
             getObject().setSubtotalStyle(subtotalStyle.build());
@@ -914,12 +546,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setImageStyle.</p>
-     *
-     * @param imageStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setImageStyle(ReportStyleBuilder imageStyle) {
         if (imageStyle != null) {
             getObject().setImageStyle(imageStyle.build());
@@ -929,12 +555,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setChartStyle.</p>
-     *
-     * @param chartStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setChartStyle(ReportStyleBuilder chartStyle) {
         if (chartStyle != null) {
             getObject().setChartStyle(chartStyle.build());
@@ -944,12 +564,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setBarcodeStyle.</p>
-     *
-     * @param barcodeStyle a {@link net.sf.dynamicreports.report.builder.style.ReportStyleBuilder} object.
-     * @return a T object.
-     */
     public T setBarcodeStyle(ReportStyleBuilder barcodeStyle) {
         if (barcodeStyle != null) {
             getObject().setBarcodeStyle(barcodeStyle.build());
@@ -960,33 +574,15 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // row highlighter
-
-    /**
-     * <p>highlightDetailOddRows.</p>
-     *
-     * @return a T object.
-     */
     public T highlightDetailOddRows() {
         return setHighlightDetailOddRows(true);
     }
 
-    /**
-     * <p>setHighlightDetailOddRows.</p>
-     *
-     * @param highlightDetailOddRows a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setHighlightDetailOddRows(Boolean highlightDetailOddRows) {
         getObject().setHighlightDetailOddRows(highlightDetailOddRows);
         return (T) this;
     }
 
-    /**
-     * <p>setDetailOddRowStyle.</p>
-     *
-     * @param detailOddRowStyle a {@link net.sf.dynamicreports.report.builder.style.SimpleStyleBuilder} object.
-     * @return a T object.
-     */
     public T setDetailOddRowStyle(SimpleStyleBuilder detailOddRowStyle) {
         if (detailOddRowStyle != null) {
             getObject().setDetailOddRowStyle(detailOddRowStyle.build());
@@ -996,32 +592,15 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>highlightDetailEvenRows.</p>
-     *
-     * @return a T object.
-     */
     public T highlightDetailEvenRows() {
         return setHighlightDetailEvenRows(true);
     }
 
-    /**
-     * <p>setHighlightDetailEvenRows.</p>
-     *
-     * @param highlightDetailEvenRows a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setHighlightDetailEvenRows(Boolean highlightDetailEvenRows) {
         getObject().setHighlightDetailEvenRows(highlightDetailEvenRows);
         return (T) this;
     }
 
-    /**
-     * <p>setDetailEvenRowStyle.</p>
-     *
-     * @param detailEvenRowStyle a {@link net.sf.dynamicreports.report.builder.style.SimpleStyleBuilder} object.
-     * @return a T object.
-     */
     public T setDetailEvenRowStyle(SimpleStyleBuilder detailEvenRowStyle) {
         if (detailEvenRowStyle != null) {
             getObject().setDetailEvenRowStyle(detailEvenRowStyle.build());
@@ -1031,22 +610,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>detailRowHighlighters.</p>
-     *
-     * @param detailRowHighlighters a {@link net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder} object.
-     * @return a T object.
-     */
     public T detailRowHighlighters(ConditionalStyleBuilder... detailRowHighlighters) {
         return addDetailRowHighlighter(detailRowHighlighters);
     }
 
-    /**
-     * <p>addDetailRowHighlighter.</p>
-     *
-     * @param detailRowHighlighters a {@link net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder} object.
-     * @return a T object.
-     */
     public T addDetailRowHighlighter(ConditionalStyleBuilder... detailRowHighlighters) {
         Validate.notNull(detailRowHighlighters, "detailRowHighlighters must not be null");
         Validate.noNullElements(detailRowHighlighters, "detailRowHighlighters must not contains null detailRowHighlighter");
@@ -1057,23 +624,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // subtotal
-
-    /**
-     * <p>subtotalsAtTitle.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtTitle(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtTitle(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtTitle.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtTitle(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1083,22 +637,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtPageHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtPageHeader(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtPageHeader(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtPageHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtPageHeader(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1108,22 +650,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtPageFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtPageFooter(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtPageFooter(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtPageFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtPageFooter(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1133,22 +663,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtColumnHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtColumnHeader(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtColumnHeader(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtColumnHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtColumnHeader(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1158,22 +676,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtColumnFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtColumnFooter(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtColumnFooter(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtColumnFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtColumnFooter(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1183,24 +689,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtGroupHeader.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtGroupHeader(GroupBuilder<?> group, SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtGroupHeader(group, subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtGroupHeader.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtGroupHeader(GroupBuilder<?> group, SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(group, "group must not be null");
         Validate.notNull(subtotals, "subtotals must not be null");
@@ -1211,24 +703,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtGroupFooter.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtGroupFooter(GroupBuilder<?> group, SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtGroupFooter(group, subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtGroupFooter.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtGroupFooter(GroupBuilder<?> group, SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(group, "group must not be null");
         Validate.notNull(subtotals, "subtotals must not be null");
@@ -1239,22 +717,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtFirstGroupHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtFirstGroupHeader(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtFirstGroupHeader(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtFirstGroupHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtFirstGroupHeader(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1264,22 +730,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtFirstGroupFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtFirstGroupFooter(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtFirstGroupFooter(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtFirstGroupFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtFirstGroupFooter(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1289,22 +743,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtLastGroupHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtLastGroupHeader(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtLastGroupHeader(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtLastGroupHeader.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtLastGroupHeader(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1314,22 +756,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtLastGroupFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtLastGroupFooter(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtLastGroupFooter(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtLastGroupFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtLastGroupFooter(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1339,22 +769,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtLastPageFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtLastPageFooter(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtLastPageFooter(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtLastPageFooter.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtLastPageFooter(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1364,22 +782,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsAtSummary.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsAtSummary(SubtotalBuilder<?, ?>... subtotals) {
         return addSubtotalAtSummary(subtotals);
     }
 
-    /**
-     * <p>addSubtotalAtSummary.</p>
-     *
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.SubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalAtSummary(SubtotalBuilder<?, ?>... subtotals) {
         Validate.notNull(subtotals, "subtotals must not be null");
         Validate.noNullElements(subtotals, "subtotals must not contains null subtotal");
@@ -1389,24 +795,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsOfPercentageAtGroupHeader.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsOfPercentageAtGroupHeader(GroupBuilder<?> group, PercentageSubtotalBuilder... subtotals) {
         return addSubtotalOfPercentageAtGroupHeader(group, subtotals);
     }
 
-    /**
-     * <p>addSubtotalOfPercentageAtGroupHeader.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalOfPercentageAtGroupHeader(GroupBuilder<?> group, PercentageSubtotalBuilder... subtotals) {
         Validate.notNull(group, "group must not be null");
         Validate.notNull(subtotals, "subtotals must not be null");
@@ -1417,24 +809,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>subtotalsOfPercentageAtGroupFooter.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     * @return a T object.
-     */
     public T subtotalsOfPercentageAtGroupFooter(GroupBuilder<?> group, PercentageSubtotalBuilder... subtotals) {
         return addSubtotalOfPercentageAtGroupFooter(group, subtotals);
     }
 
-    /**
-     * <p>addSubtotalOfPercentageAtGroupFooter.</p>
-     *
-     * @param group     a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param subtotals a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     * @return a T object.
-     */
     public T addSubtotalOfPercentageAtGroupFooter(GroupBuilder<?> group, PercentageSubtotalBuilder... subtotals) {
         Validate.notNull(group, "group must not be null");
         Validate.notNull(subtotals, "subtotals must not be null");
@@ -1446,13 +824,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // group
-
-    /**
-     * <p>groupBy.</p>
-     *
-     * @param groupColumns a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a T object.
-     */
     public T groupBy(ValueColumnBuilder<?, ?>... groupColumns) {
         Validate.notNull(groupColumns, "groupColumns must not be null");
         Validate.noNullElements(groupColumns, "groupColumns must not contains null groupColumn");
@@ -1462,22 +833,10 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>groupBy.</p>
-     *
-     * @param groups a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @return a T object.
-     */
     public T groupBy(GroupBuilder<?>... groups) {
         return addGroup(groups);
     }
 
-    /**
-     * <p>addGroup.</p>
-     *
-     * @param groups a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @return a T object.
-     */
     public T addGroup(GroupBuilder<?>... groups) {
         Validate.notNull(groups, "groups must not be null");
         Validate.noNullElements(groups, "groups must not contains null group");
@@ -1488,71 +847,36 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     // table of contents
-
-    /**
-     * <p>tableOfContents.</p>
-     *
-     * @return a T object.
-     */
     public T tableOfContents() {
         return setTableOfContents(true);
     }
 
-    /**
-     * <p>tableOfContents.</p>
-     *
-     * @param tableOfContentsCustomizer a {@link net.sf.dynamicreports.report.builder.tableofcontents.TableOfContentsCustomizerBuilder} object.
-     * @return a T object.
-     */
     public T tableOfContents(TableOfContentsCustomizerBuilder tableOfContentsCustomizer) {
         return setTableOfContents(tableOfContentsCustomizer);
     }
 
-    /**
-     * <p>tableOfContents.</p>
-     *
-     * @param tableOfContentsCustomizer a {@link net.sf.dynamicreports.report.definition.DRITableOfContentsCustomizer} object.
-     * @return a T object.
-     */
     public T tableOfContents(DRITableOfContentsCustomizer tableOfContentsCustomizer) {
         return setTableOfContents(tableOfContentsCustomizer);
     }
 
-    /**
-     * <p>setTableOfContents.</p>
-     *
-     * @param tableOfContents a {@link java.lang.Boolean} object.
-     * @return a T object.
-     */
     public T setTableOfContents(Boolean tableOfContents) {
         getObject().setTableOfContents(tableOfContents);
         return (T) this;
     }
 
-    /**
-     * <p>setTableOfContents.</p>
-     *
-     * @param tableOfContentsCustomizer a {@link net.sf.dynamicreports.report.builder.tableofcontents.TableOfContentsCustomizerBuilder} object.
-     * @return a T object.
-     */
     public T setTableOfContents(TableOfContentsCustomizerBuilder tableOfContentsCustomizer) {
         getObject().setTableOfContentsCustomizer(tableOfContentsCustomizer.build());
         return setTableOfContents(true);
     }
 
-    /**
-     * <p>setTableOfContents.</p>
-     *
-     * @param tableOfContentsCustomizer a {@link net.sf.dynamicreports.report.definition.DRITableOfContentsCustomizer} object.
-     * @return a T object.
-     */
     public T setTableOfContents(DRITableOfContentsCustomizer tableOfContentsCustomizer) {
         getObject().setTableOfContentsCustomizer(tableOfContentsCustomizer);
         return setTableOfContents(true);
     }
 
     /**
-     * Sets a dataset filter expression. The expression must be a type of Boolean
+     * Sets a dataset filter expression.
+     * The expression must be a type of Boolean
      *
      * @param filterExpression the filter expression
      * @return a report builder
@@ -1578,12 +902,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setTitlePrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setTitlePrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getTitleBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -1604,12 +922,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setTitleBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setTitleBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getTitleBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -1617,7 +929,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the title band. The band is printed on the first page and only once.
+     * Adds components to the title band.
+     * The band is printed on the first page and only once.
      *
      * @param components the title components
      * @return a report builder
@@ -1627,7 +940,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the title band. The band is printed on the first page and only once.
+     * Adds components to the title band.
+     * The band is printed on the first page and only once.
      *
      * @param components the title components
      * @return a report builder
@@ -1657,12 +971,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setPageHeaderPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setPageHeaderPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getPageHeaderBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -1683,12 +991,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setPageHeaderBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setPageHeaderBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getPageHeaderBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -1696,7 +998,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the page header band. The band is printed on each page at the top of the page.
+     * Adds components to the page header band.
+     * The band is printed on each page at the top of the page.
      *
      * @param components the page header components
      * @return a report builder
@@ -1706,7 +1009,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the page header band. The band is printed on each page at the top of the page.
+     * Adds components to the page header band.
+     * The band is printed on each page at the top of the page.
      *
      * @param components the page header components
      * @return a report builder
@@ -1736,12 +1040,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setPageFooterPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setPageFooterPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getPageFooterBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -1762,12 +1060,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setPageFooterBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setPageFooterBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getPageFooterBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -1775,7 +1067,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the page footer band. The band is printed on each page at the bottom of the page.
+     * Adds components to the page footer band.
+     * The band is printed on each page at the bottom of the page.
      *
      * @param components the page footer components
      * @return a report builder
@@ -1785,7 +1078,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the page footer band. The band is printed on each page at the bottom of the page.
+     * Adds components to the page footer band.
+     * The band is printed on each page at the bottom of the page.
      *
      * @param components the page footer components
      * @return a report builder
@@ -1815,12 +1109,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnHeaderPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setColumnHeaderPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getColumnHeaderBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -1841,12 +1129,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnHeaderBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setColumnHeaderBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getColumnHeaderBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -1854,7 +1136,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the column header band. The band is printed on each page at the top of the page and it's placed below the page header band.
+     * Adds components to the column header band.
+     * The band is printed on each page at the top of the page and it's placed below the page header band.
      *
      * @param components the column header components
      * @return a report builder
@@ -1864,7 +1147,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the column header band. The band is printed on each page at the top of the page and it's placed below the page header band.
+     * Adds components to the column header band.
+     * The band is printed on each page at the top of the page and it's placed below the page header band.
      *
      * @param components the column header components
      * @return a report builder
@@ -1894,12 +1178,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnFooterPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setColumnFooterPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getColumnFooterBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -1920,12 +1198,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setColumnFooterBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setColumnFooterBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getColumnFooterBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -1933,7 +1205,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the column footer band. The band is printed on each page at the bottom of the page and it's placed above the page footer band.
+     * Adds components to the column footer band.
+     * The band is printed on each page at the bottom of the page and it's placed above the page footer band.
      *
      * @param components the column footer components
      * @return a report builder
@@ -1943,7 +1216,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the column footer band. The band is printed on each page at the bottom of the page and it's placed above the page footer band.
+     * Adds components to the column footer band.
+     * The band is printed on each page at the bottom of the page and it's placed above the page footer band.
      *
      * @param components the column footer components
      * @return a report builder
@@ -1978,13 +1252,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupHeaderPrintWhenExpression.</p>
-     *
-     * @param group               a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setGroupHeaderPrintWhenExpression(GroupBuilder<?> group, DRIExpression<Boolean> printWhenExpression) {
         Validate.notNull(group, "group must not be null");
         int index = getObject().getGroups().indexOf(group.getGroup());
@@ -2014,13 +1281,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupHeaderBackgroundComponent.</p>
-     *
-     * @param group               a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setGroupHeaderBackgroundComponent(GroupBuilder<?> group, ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         Validate.notNull(group, "group must not be null");
@@ -2032,7 +1292,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the group header band. The band is printed for each data group. It's placed above the grouped data and between the column header and footer.
+     * Adds components to the group header band.
+     * The band is printed for each data group. It's placed above the grouped data and between the column header and footer.
      *
      * @param group      the group to which to add the components
      * @param components the group header components
@@ -2043,7 +1304,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the group header band. The band is printed for each data group. It's placed above the grouped data and between the column header and footer.
+     * Adds components to the group header band.
+     * The band is printed for each data group. It's placed above the grouped data and between the column header and footer.
      *
      * @param group      the group to which to add the components
      * @param components the group header components
@@ -2083,13 +1345,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupFooterPrintWhenExpression.</p>
-     *
-     * @param group               a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setGroupFooterPrintWhenExpression(GroupBuilder<?> group, DRIExpression<Boolean> printWhenExpression) {
         Validate.notNull(group, "group must not be null");
         int index = getObject().getGroups().indexOf(group.getGroup());
@@ -2119,13 +1374,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setGroupFooterBackgroundComponent.</p>
-     *
-     * @param group               a {@link net.sf.dynamicreports.report.builder.group.GroupBuilder} object.
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setGroupFooterBackgroundComponent(GroupBuilder<?> group, ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         Validate.notNull(group, "group must not be null");
@@ -2137,7 +1385,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the group footer band. The band is printed for each data group. It's placed below the grouped data and between the column header and footer.
+     * Adds components to the group footer band.
+     * The band is printed for each data group. It's placed below the grouped data and between the column header and footer.
      *
      * @param group      the group to which to add the components
      * @param components the group footer components
@@ -2148,7 +1397,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the group footer band. The band is printed for each data group. It's placed below the grouped data and between the column header and footer.
+     * Adds components to the group footer band.
+     * The band is printed for each data group. It's placed below the grouped data and between the column header and footer.
      *
      * @param group      the group to which to add the components
      * @param components the group footer components
@@ -2183,12 +1433,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setDetailPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getDetailBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2209,12 +1453,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setDetailBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getDetailBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2222,7 +1460,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail band. The band is printed for each record row in the data source and it's placed between the column header and footer band.
+     * Adds components to the detail band.
+     * The band is printed for each record row in the data source and it's placed between the column header and footer band.
      *
      * @param components the detail components
      * @return a report builder
@@ -2232,7 +1471,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail band. The band is printed for each record row in the data source and it's placed between the column header and footer band.
+     * Adds components to the detail band.
+     * The band is printed for each record row in the data source and it's placed between the column header and footer band.
      *
      * @param components the detail components
      * @return a report builder
@@ -2262,12 +1502,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailHeaderPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setDetailHeaderPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getDetailHeaderBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2288,12 +1522,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailHeaderBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setDetailHeaderBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getDetailHeaderBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2301,7 +1529,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail header band. The band is printed for each record row in the data source and it's placed above the detail band.
+     * Adds components to the detail header band.
+     * The band is printed for each record row in the data source and it's placed above the detail band.
      *
      * @param components the detail header components
      * @return a report builder
@@ -2311,7 +1540,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail header band. The band is printed for each record row in the data source and it's placed above the detail band.
+     * Adds components to the detail header band.
+     * The band is printed for each record row in the data source and it's placed above the detail band.
      *
      * @param components the detail header components
      * @return a report builder
@@ -2341,12 +1571,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailFooterPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setDetailFooterPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getDetailFooterBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2367,12 +1591,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setDetailFooterBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setDetailFooterBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getDetailFooterBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2380,7 +1598,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail footer band. The band is printed for each record row in the data source and it's placed below the detail band.
+     * Adds components to the detail footer band.
+     * The band is printed for each record row in the data source and it's placed below the detail band.
      *
      * @param components the detail footer components
      * @return a report builder
@@ -2390,7 +1609,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the detail footer band. The band is printed for each record row in the data source and it's placed below the detail band.
+     * Adds components to the detail footer band.
+     * The band is printed for each record row in the data source and it's placed below the detail band.
      *
      * @param components the detail footer components
      * @return a report builder
@@ -2420,12 +1640,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setLastPageFooterPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setLastPageFooterPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getLastPageFooterBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2446,12 +1660,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setLastPageFooterBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setLastPageFooterBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getLastPageFooterBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2459,7 +1667,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the last page footer band. The band is printed only on the last page at the bottom of the page.
+     * Adds components to the last page footer band.
+     * The band is printed only on the last page at the bottom of the page.
      *
      * @param components the last page footer components
      * @return a report builder
@@ -2469,7 +1678,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the last page footer band. The band is printed only on the last page at the bottom of the page.
+     * Adds components to the last page footer band.
+     * The band is printed only on the last page at the bottom of the page.
      *
      * @param components the last page footer components
      * @return a report builder
@@ -2499,12 +1709,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setSummaryPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setSummaryPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getSummaryBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2525,12 +1729,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setSummaryBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setSummaryBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getSummaryBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2538,7 +1736,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the summary band. The band is printed on the last page and only once.
+     * Adds components to the summary band.
+     * The band is printed on the last page and only once.
      *
      * @param components the summary components
      * @return a report builder
@@ -2548,7 +1747,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the summary band. The band is printed on the last page and only once.
+     * Adds components to the summary band.
+     * The band is printed on the last page and only once.
      *
      * @param components the summary components
      * @return a report builder
@@ -2578,12 +1778,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setNoDataPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setNoDataPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getNoDataBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2604,12 +1798,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setNoDataBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setNoDataBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getNoDataBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2617,7 +1805,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the no data band. The band is printed only when the data source is empty. It's used to show the information that there are not any data in the report.
+     * Adds components to the no data band.
+     * The band is printed only when the data source is empty. It's used to show the information that there are not any data in the report.
      *
      * @param components the no data components
      * @return a report builder
@@ -2627,7 +1816,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the no data band. The band is printed only when the data source is empty. It's used to show the information that there are not any data in the report.
+     * Adds components to the no data band.
+     * The band is printed only when the data source is empty. It's used to show the information that there are not any data in the report.
      *
      * @param components the no data components
      * @return a report builder
@@ -2657,12 +1847,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setBackgroundPrintWhenExpression.</p>
-     *
-     * @param printWhenExpression a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @return a T object.
-     */
     public T setBackgroundPrintWhenExpression(DRIExpression<Boolean> printWhenExpression) {
         getObject().getBackgroundBand().setPrintWhenExpression(printWhenExpression);
         return (T) this;
@@ -2683,12 +1867,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>setBackgroundBackgroundComponent.</p>
-     *
-     * @param backgroundComponent a {@link net.sf.dynamicreports.report.builder.component.ComponentBuilder} object.
-     * @return a T object.
-     */
     public T setBackgroundBackgroundComponent(ComponentBuilder<?, ?> backgroundComponent) {
         Validate.notNull(backgroundComponent, "backgroundComponent must not be null");
         getObject().getBackgroundBand().getList().setBackgroundComponent(backgroundComponent.build());
@@ -2696,7 +1874,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the background band. The band is printed on each page. It's mostly used for adding watermarks to the report.
+     * Adds components to the background band.
+     * The band is printed on each page. It's mostly used for adding watermarks to the report.
      *
      * @param components the background components
      * @return a report builder
@@ -2706,7 +1885,8 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
     }
 
     /**
-     * Adds components to the background band. The band is printed on each page. It's mostly used for adding watermarks to the report.
+     * Adds components to the background band.
+     * The band is printed on each page. It's mostly used for adding watermarks to the report.
      *
      * @param components the background components
      * @return a report builder
@@ -2720,11 +1900,6 @@ public class ReportBuilder<T extends ReportBuilder<T>> extends AbstractBuilder<T
         return (T) this;
     }
 
-    /**
-     * <p>getReport.</p>
-     *
-     * @return a {@link net.sf.dynamicreports.report.base.DRReport} object.
-     */
     public DRReport getReport() {
         return build();
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/VariableBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/VariableBuilder.java
@@ -156,9 +156,7 @@ public class VariableBuilder<T> extends AbstractBuilder<VariableBuilder<T>, DRVa
         return build();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getVariable().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/ScatterChartBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/ScatterChartBuilder.java
@@ -85,8 +85,8 @@ public class ScatterChartBuilder extends AbstractXyChartBuilder<ScatterChartBuil
         return this;
     }
 
-	/*public ScatterChartBuilder setPercentValuePattern(String percentValuePattern) {
-		getPlot().setPercentValuePattern(percentValuePattern);
-		return this;
-	}*/
+    /*public ScatterChartBuilder setPercentValuePattern(String percentValuePattern) {
+        getPlot().setPercentValuePattern(percentValuePattern);
+        return this;
+    }*/
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/SeriesOrderByNamesComparator.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/SeriesOrderByNamesComparator.java
@@ -52,9 +52,7 @@ public class SeriesOrderByNamesComparator implements Comparator<String>, Seriali
         this.seriesNames = seriesNames;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public int compare(String o1, String o2) {
         String row1;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyBarChartBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyBarChartBuilder.java
@@ -74,18 +74,18 @@ public class XyBarChartBuilder extends AbstractXyChartBuilder<XyBarChartBuilder,
         return this;
     }
 
-	/*public XyBarChartBuilder setPercentValuePattern(String percentValuePattern) {
-		getPlot().setPercentValuePattern(percentValuePattern);
-		return this;
-	}*/
+    /*public XyBarChartBuilder setPercentValuePattern(String percentValuePattern) {
+        getPlot().setPercentValuePattern(percentValuePattern);
+        return this;
+    }*/
 
-	/*public XyBarChartBuilder setShowTickLabels(boolean showTickLabels) {
-		getPlot().setShowTickLabels(showTickLabels);
-		return this;
-	}
-	
-	public XyBarChartBuilder setShowTickMarks(boolean showTickMarks) {
-		getPlot().setShowTickMarks(showTickMarks);
-		return this;
-	}*/
+    /*public XyBarChartBuilder setShowTickLabels(boolean showTickLabels) {
+        getPlot().setShowTickLabels(showTickLabels);
+        return this;
+    }
+
+    public XyBarChartBuilder setShowTickMarks(boolean showTickMarks) {
+        getPlot().setShowTickMarks(showTickMarks);
+        return this;
+    }*/
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyLineChartBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyLineChartBuilder.java
@@ -85,8 +85,8 @@ public class XyLineChartBuilder extends AbstractXyChartBuilder<XyLineChartBuilde
         return this;
     }
 
-	/*public XyLineChartBuilder setPercentValuePattern(String percentValuePattern) {
-		getPlot().setPercentValuePattern(percentValuePattern);
-		return this;
-	}*/
+    /*public XyLineChartBuilder setPercentValuePattern(String percentValuePattern) {
+        getPlot().setPercentValuePattern(percentValuePattern);
+        return this;
+    }*/
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyStepChartBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/chart/XyStepChartBuilder.java
@@ -63,10 +63,10 @@ public class XyStepChartBuilder extends AbstractXyChartBuilder<XyStepChartBuilde
         return this;
     }
 
-	/*public XyStepChartBuilder setPercentValuePattern(String percentValuePattern) {
-		getPlot().setPercentValuePattern(percentValuePattern);
-		return this;
-	}*/
+    /*public XyStepChartBuilder setPercentValuePattern(String percentValuePattern) {
+        getPlot().setPercentValuePattern(percentValuePattern);
+        return this;
+    }*/
 
     /**
      * <p>setStepPoint.</p>

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/BooleanColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/BooleanColumnBuilder.java
@@ -69,7 +69,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param width the column preferred width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setWidth(Integer width) {
@@ -82,7 +82,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param width the column fixed width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setFixedWidth(Integer width) {
@@ -96,7 +96,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param width the column minimum width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setMinWidth(Integer width) {
@@ -110,7 +110,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param height the column preferred height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setHeight(Integer height) {
@@ -123,7 +123,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param height the column fixed height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setFixedHeight(Integer height) {
@@ -137,7 +137,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
      *
      * @param height the column minimum height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public BooleanColumnBuilder setMinHeight(Integer height) {
@@ -244,9 +244,7 @@ public class BooleanColumnBuilder extends ColumnBuilder<BooleanColumnBuilder, DR
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected DRBooleanField getComponent() {
         return (DRBooleanField) getObject().getComponent();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ColumnBuilder.java
@@ -119,7 +119,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param rows the number of preferred rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setTitleRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -131,7 +131,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param rows the number of fixed rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setTitleFixedRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -144,7 +144,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param rows the number of minimum rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setTitleMinRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -157,7 +157,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param height the column title preferred height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setTitleHeight(Integer height) {
@@ -170,7 +170,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param height the column title fixed height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setTitleFixedHeight(Integer height) {
@@ -184,7 +184,7 @@ public abstract class ColumnBuilder<T extends ColumnBuilder<T, U>, U extends DRC
      *
      * @param height the column title minimum height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setTitleMinHeight(Integer height) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ColumnBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ColumnBuilders.java
@@ -201,13 +201,13 @@ public class ColumnBuilders {
         return Columns.percentageColumn(title, field);
     }
 
-	/*public PercentageColumnBuilder percentageColumn(DRISimpleExpression<? extends Number> expression) {
-		return Columns.percentageColumn(expression);
-	}
-	
-	public PercentageColumnBuilder percentageColumn(String title, DRISimpleExpression<? extends Number> expression) {
-		return Columns.percentageColumn(title, expression);
-	}*/
+    /*public PercentageColumnBuilder percentageColumn(DRISimpleExpression<? extends Number> expression) {
+        return Columns.percentageColumn(expression);
+    }
+
+    public PercentageColumnBuilder percentageColumn(String title, DRISimpleExpression<? extends Number> expression) {
+        return Columns.percentageColumn(title, expression);
+    }*/
 
     // column row number
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/Columns.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/Columns.java
@@ -218,13 +218,13 @@ public class Columns {
         return percentageColumn(field).setTitle(title);
     }
 
-	/*public static PercentageColumnBuilder percentageColumn(DRISimpleExpression<? extends Number> expression) {
-		return new PercentageColumnBuilder(expression);
-	}
-	
-	public static PercentageColumnBuilder percentageColumn(String title, DRISimpleExpression<? extends Number> expression) {
-		return percentageColumn(expression).setTitle(title);
-	}	*/
+    /*public static PercentageColumnBuilder percentageColumn(DRISimpleExpression<? extends Number> expression) {
+        return new PercentageColumnBuilder(expression);
+    }
+
+    public static PercentageColumnBuilder percentageColumn(String title, DRISimpleExpression<? extends Number> expression) {
+        return percentageColumn(expression).setTitle(title);
+    }*/
 
     // column row number
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ComponentColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ComponentColumnBuilder.java
@@ -53,7 +53,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param width the column preferred width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setWidth(Integer width) {
@@ -66,7 +66,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param width the column fixed width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setFixedWidth(Integer width) {
@@ -80,7 +80,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param width the column minimum width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setMinWidth(Integer width) {
@@ -94,7 +94,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param height the column preferred height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setHeight(Integer height) {
@@ -107,7 +107,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param height the column fixed height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setFixedHeight(Integer height) {
@@ -121,7 +121,7 @@ public class ComponentColumnBuilder extends ColumnBuilder<ComponentColumnBuilder
      *
      * @param height the column minimum height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ComponentColumnBuilder setMinHeight(Integer height) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/PercentageColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/PercentageColumnBuilder.java
@@ -68,10 +68,10 @@ public class PercentageColumnBuilder extends ValueColumnBuilder<PercentageColumn
         this.actualExpression = field.getField();
     }
 
-	/*protected PercentageColumnBuilder(DRISimpleExpression<? extends Number> valueExpression) {
-		Validate.notNull(valueExpression, "valueExpression must not be null");
-		this.actualExpression = valueExpression;
-	}*/
+    /*protected PercentageColumnBuilder(DRISimpleExpression<? extends Number> valueExpression) {
+        Validate.notNull(valueExpression, "valueExpression must not be null");
+        this.actualExpression = valueExpression;
+    }*/
 
     /**
      * Sets the total type. Has effect only when the report contains at least one group.

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/PercentageColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/PercentageColumnBuilder.java
@@ -101,9 +101,7 @@ public class PercentageColumnBuilder extends ValueColumnBuilder<PercentageColumn
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getComponent().getDataType() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/TextColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/TextColumnBuilder.java
@@ -195,9 +195,7 @@ public class TextColumnBuilder<T> extends ValueColumnBuilder<TextColumnBuilder<T
         return new TextColumnBuilder<BigDecimal>(exp).setDataType(type.bigDecimalType());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getObject().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ValueColumnBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/column/ValueColumnBuilder.java
@@ -149,7 +149,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param columns the number of preferred columns >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public T setColumns(Integer columns) {
         getComponent().setColumns(columns);
@@ -161,7 +161,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param columns the number of fixed columns >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public T setFixedColumns(Integer columns) {
         getComponent().setColumns(columns);
@@ -174,7 +174,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param columns the number of minimum columns >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public T setMinColumns(Integer columns) {
         getComponent().setColumns(columns);
@@ -187,7 +187,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param rows the number of preferred rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setRows(Integer rows) {
         getComponent().setRows(rows);
@@ -199,7 +199,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param rows the number of fixed rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setFixedRows(Integer rows) {
         getComponent().setRows(rows);
@@ -212,7 +212,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param rows the number of minimum rows >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public T setMinRows(Integer rows) {
         getComponent().setRows(rows);
@@ -273,7 +273,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param width the column preferred width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setWidth(Integer width) {
@@ -286,7 +286,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param width the column fixed width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setFixedWidth(Integer width) {
@@ -300,7 +300,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param width the column minimum width >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setMinWidth(Integer width) {
@@ -314,7 +314,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param height the column preferred height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setHeight(Integer height) {
@@ -327,7 +327,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param height the column fixed height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setFixedHeight(Integer height) {
@@ -341,7 +341,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
      *
      * @param height the column minimum height >= 0
      * @return a column builder
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setMinHeight(Integer height) {
@@ -436,9 +436,7 @@ public abstract class ValueColumnBuilder<T extends ValueColumnBuilder<T, U>, U> 
         return (T) this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected DRTextField<U> getComponent() {
         return (DRTextField<U>) getObject().getComponent();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/ComponentBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/ComponentBuilders.java
@@ -293,7 +293,6 @@ public class ComponentBuilders {
      * <p>text.</p>
      *
      * @param number a T object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
      */
     public <T extends Number> TextFieldBuilder<T> text(T number) {
@@ -517,6 +516,7 @@ public class ComponentBuilders {
     /**
      * <p>genericElement.</p>
      *
+     * @param namespace a {@link java.lang.String} object.
      * @param namespace a {@link java.lang.String} object.
      * @param name      a {@link java.lang.String} object.
      * @return a {@link net.sf.dynamicreports.report.builder.component.GenericElementBuilder} object.

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/Components.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/Components.java
@@ -300,7 +300,6 @@ public class Components {
      * <p>text.</p>
      *
      * @param number a T object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
      */
     public static <T extends Number> TextFieldBuilder<T> text(T number) {
@@ -532,6 +531,7 @@ public class Components {
     /**
      * <p>genericElement.</p>
      *
+     * @param namespace a {@link java.lang.String} object.
      * @param namespace a {@link java.lang.String} object.
      * @param name      a {@link java.lang.String} object.
      * @return a {@link net.sf.dynamicreports.report.builder.component.GenericElementBuilder} object.

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/CurrentDateBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/CurrentDateBuilder.java
@@ -52,9 +52,7 @@ public class CurrentDateBuilder extends AbstractFormatFieldBuilder<CurrentDateBu
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getFormatExpression() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/DimensionComponentBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/DimensionComponentBuilder.java
@@ -54,10 +54,22 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      * @param width  the component preferred width >= 0
      * @param height the component preferred height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setDimension(Integer width, Integer height) {
@@ -72,10 +84,22 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      * @param width  the component fixed width >= 0
      * @param height the component fixed height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setFixedDimension(Integer width, Integer height) {
@@ -92,10 +116,22 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      * @param width  the component minimum width >= 0
      * @param height the component minimum height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
-     * @throws IllegalArgumentException if <code>width</code> is < 0
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setMinDimension(Integer width, Integer height) {
@@ -111,7 +147,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param width the component preferred width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setWidth(Integer width) {
@@ -124,7 +160,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param width the component fixed width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setFixedWidth(Integer width) {
@@ -138,7 +174,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param width the component minimum width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setMinWidth(Integer width) {
@@ -152,7 +188,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param height the component preferred height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setHeight(Integer height) {
@@ -165,7 +201,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param height the component fixed height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setFixedHeight(Integer height) {
@@ -179,7 +215,7 @@ public abstract class DimensionComponentBuilder<T extends DimensionComponentBuil
      *
      * @param height the component minimum height >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setMinHeight(Integer height) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/GenericElementBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/GenericElementBuilder.java
@@ -40,6 +40,7 @@ public class GenericElementBuilder extends DimensionComponentBuilder<GenericElem
      * <p>Constructor for GenericElementBuilder.</p>
      *
      * @param namespace a {@link java.lang.String} object.
+     * @param namespace a {@link java.lang.String} object.
      * @param name      a {@link java.lang.String} object.
      */
     protected GenericElementBuilder(String namespace, String name) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/HorizontalFlowListBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/HorizontalFlowListBuilder.java
@@ -38,9 +38,7 @@ public class HorizontalFlowListBuilder extends HorizontalListBuilder {
     protected HorizontalFlowListBuilder() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         newFlowRow();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/HorizontalListBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/HorizontalListBuilder.java
@@ -178,9 +178,7 @@ public class HorizontalListBuilder extends DimensionComponentBuilder<HorizontalL
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalListBuilder setStyle(ReportStyleBuilder style) {
         if (style != null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageNumberBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageNumberBuilder.java
@@ -41,9 +41,7 @@ public class PageNumberBuilder extends AbstractFormatFieldBuilder<PageNumberBuil
         super(new DRPageNumber());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getFormatExpression() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageXofYBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageXofYBuilder.java
@@ -47,7 +47,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageX component preferred width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageXWidth(Integer width) {
@@ -60,7 +60,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageX component fixed width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageXFixedWidth(Integer width) {
@@ -74,7 +74,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageX component minimum width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageXMinWidth(Integer width) {
@@ -88,7 +88,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageY component preferred width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageYWidth(Integer width) {
@@ -101,7 +101,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageY component fixed width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageYFixedWidth(Integer width) {
@@ -115,7 +115,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
      *
      * @param width the pageY component minimum width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXofYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXofYBuilder setPageYMinWidth(Integer width) {
@@ -124,9 +124,7 @@ public class PageXofYBuilder extends AbstractFormatFieldBuilder<PageXofYBuilder,
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getFormatExpression() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageXslashYBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/PageXslashYBuilder.java
@@ -47,7 +47,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageX component preferred width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageXWidth(Integer width) {
@@ -60,7 +60,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageX component fixed width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageXFixedWidth(Integer width) {
@@ -74,7 +74,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageX component minimum width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageXMinWidth(Integer width) {
@@ -88,7 +88,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageY component preferred width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageYWidth(Integer width) {
@@ -101,7 +101,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageY component fixed width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageYFixedWidth(Integer width) {
@@ -115,7 +115,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
      *
      * @param width the pageY component minimum width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.PageXslashYBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public PageXslashYBuilder setPageYMinWidth(Integer width) {
@@ -124,9 +124,7 @@ public class PageXslashYBuilder extends AbstractFormatFieldBuilder<PageXslashYBu
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getFormatExpression() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/TextFieldBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/TextFieldBuilder.java
@@ -211,7 +211,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param columns the number of preferred columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public TextFieldBuilder<T> setColumns(Integer columns) {
         getObject().setColumns(columns);
@@ -223,7 +223,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param columns the number of fixed columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public TextFieldBuilder<T> setFixedColumns(Integer columns) {
         getObject().setColumns(columns);
@@ -236,7 +236,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param columns the number of minimum columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public TextFieldBuilder<T> setMinColumns(Integer columns) {
         getObject().setColumns(columns);
@@ -249,7 +249,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param rows the number of preferred rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public TextFieldBuilder<T> setRows(Integer rows) {
         getObject().setRows(rows);
@@ -261,7 +261,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param rows the number of fixed rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public TextFieldBuilder<T> setFixedRows(Integer rows) {
         getObject().setRows(rows);
@@ -274,7 +274,7 @@ public class TextFieldBuilder<T> extends HyperLinkComponentBuilder<TextFieldBuil
      *
      * @param rows the number of minimum rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.component.TextFieldBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public TextFieldBuilder<T> setMinRows(Integer rows) {
         getObject().setRows(rows);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/TotalPagesBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/component/TotalPagesBuilder.java
@@ -41,9 +41,7 @@ public class TotalPagesBuilder extends AbstractFormatFieldBuilder<TotalPagesBuil
         super(new DRTotalPages());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getFormatExpression() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractBetweenValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractBetweenValueExpression.java
@@ -57,9 +57,7 @@ public abstract class AbstractBetweenValueExpression<T extends Number> extends A
         this.max = max;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         Number actualValue = reportParameters.getValue(value);
@@ -69,9 +67,7 @@ public abstract class AbstractBetweenValueExpression<T extends Number> extends A
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractValueExpression.java
@@ -52,9 +52,7 @@ public abstract class AbstractValueExpression<T extends Number> extends Abstract
         this.number = number;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         Number actualValue = reportParameters.getValue(value);
@@ -64,9 +62,7 @@ public abstract class AbstractValueExpression<T extends Number> extends Abstract
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractValuesExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/AbstractValuesExpression.java
@@ -52,9 +52,7 @@ public abstract class AbstractValuesExpression<T extends Number> extends Abstrac
         this.numbers = numbers;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         Number actualValue = reportParameters.getValue(value);
@@ -64,9 +62,7 @@ public abstract class AbstractValuesExpression<T extends Number> extends Abstrac
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/BetweenValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/BetweenValueExpression.java
@@ -44,9 +44,7 @@ public class BetweenValueExpression<T extends Number> extends AbstractBetweenVal
         super(value, min, max);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number min, Number max) {
         return actualValue.doubleValue() >= min.doubleValue() && actualValue.doubleValue() <= max.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/ConditionBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/ConditionBuilders.java
@@ -36,6 +36,7 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param values a T object.
+     * @param values a T object.
      * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.EqualExpression} object.
      */
@@ -49,7 +50,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.EqualValueExpression} object.
      */
     public <T extends Number> EqualValueExpression<T> equal(DRIValue<T> value, Number... number) {
@@ -60,6 +60,7 @@ public class ConditionBuilders {
      * <p>unEqual.</p>
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
+     * @param values a T object.
      * @param values a T object.
      * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.UnEqualExpression} object.
@@ -74,7 +75,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.UnEqualValueExpression} object.
      */
     public <T extends Number> UnEqualValueExpression<T> unEqual(DRIValue<T> value, Number... number) {
@@ -86,7 +86,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.SmallerValueExpression} object.
      */
     public <T extends Number> SmallerValueExpression<T> smaller(DRIValue<T> value, Number number) {
@@ -98,7 +97,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.SmallerOrEqualsValueExpression} object.
      */
     public <T extends Number> SmallerOrEqualsValueExpression<T> smallerOrEquals(DRIValue<T> value, Number number) {
@@ -110,7 +108,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.GreaterValueExpression} object.
      */
     public <T extends Number> GreaterValueExpression<T> greater(DRIValue<T> value, Number number) {
@@ -122,7 +119,6 @@ public class ConditionBuilders {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.GreaterOrEqualsValueExpression} object.
      */
     public <T extends Number> GreaterOrEqualsValueExpression<T> greaterOrEquals(DRIValue<T> value, Number number) {
@@ -135,7 +131,6 @@ public class ConditionBuilders {
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param min   a {@link java.lang.Number} object.
      * @param max   a {@link java.lang.Number} object.
-     * @param <T>   a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.BetweenValueExpression} object.
      */
     public <T extends Number> BetweenValueExpression<T> between(DRIValue<T> value, Number min, Number max) {
@@ -148,7 +143,6 @@ public class ConditionBuilders {
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param min   a {@link java.lang.Number} object.
      * @param max   a {@link java.lang.Number} object.
-     * @param <T>   a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.NotBetweenValueExpression} object.
      */
     public <T extends Number> NotBetweenValueExpression<T> notBetween(DRIValue<T> value, Number min, Number max) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/Conditions.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/Conditions.java
@@ -36,6 +36,7 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param values a T object.
+     * @param values a T object.
      * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.EqualExpression} object.
      */
@@ -49,7 +50,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.EqualValueExpression} object.
      */
     public static <T extends Number> EqualValueExpression<T> equal(DRIValue<T> value, Number... number) {
@@ -60,6 +60,7 @@ public class Conditions {
      * <p>unEqual.</p>
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
+     * @param values a T object.
      * @param values a T object.
      * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.UnEqualExpression} object.
@@ -74,7 +75,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.UnEqualValueExpression} object.
      */
     public static <T extends Number> UnEqualValueExpression<T> unEqual(DRIValue<T> value, Number... number) {
@@ -86,7 +86,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.SmallerValueExpression} object.
      */
     public static <T extends Number> SmallerValueExpression<T> smaller(DRIValue<T> value, Number number) {
@@ -98,7 +97,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.SmallerOrEqualsValueExpression} object.
      */
     public static <T extends Number> SmallerOrEqualsValueExpression<T> smallerOrEquals(DRIValue<T> value, Number number) {
@@ -110,7 +108,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.GreaterValueExpression} object.
      */
     public static <T extends Number> GreaterValueExpression<T> greater(DRIValue<T> value, Number number) {
@@ -122,7 +119,6 @@ public class Conditions {
      *
      * @param value  a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param number a {@link java.lang.Number} object.
-     * @param <T>    a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.GreaterOrEqualsValueExpression} object.
      */
     public static <T extends Number> GreaterOrEqualsValueExpression<T> greaterOrEquals(DRIValue<T> value, Number number) {
@@ -135,7 +131,6 @@ public class Conditions {
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param min   a {@link java.lang.Number} object.
      * @param max   a {@link java.lang.Number} object.
-     * @param <T>   a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.BetweenValueExpression} object.
      */
     public static <T extends Number> BetweenValueExpression<T> between(DRIValue<T> value, Number min, Number max) {
@@ -148,7 +143,6 @@ public class Conditions {
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param min   a {@link java.lang.Number} object.
      * @param max   a {@link java.lang.Number} object.
-     * @param <T>   a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.condition.NotBetweenValueExpression} object.
      */
     public static <T extends Number> NotBetweenValueExpression<T> notBetween(DRIValue<T> value, Number min, Number max) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/EqualExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/EqualExpression.java
@@ -41,21 +41,20 @@ public class EqualExpression extends AbstractSimpleExpression<Boolean> {
 
     @SafeVarargs
     /**
-     * <p>Constructor for EqualExpression.</p>
+     * Constructor for EqualExpression.
      *
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param values a T object.
      * @param <T> a T object.
-     */ public <T> EqualExpression(DRIValue<T> value, T... values) {
+     */
+    public <T> EqualExpression(DRIValue<T> value, T... values) {
         Validate.notNull(value, "value must not be null");
         Validate.noNullElements(values, "values must not contains null value");
         this.value = value;
         this.values = values;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         Object actualValue = reportParameters.getValue(value);
@@ -67,9 +66,7 @@ public class EqualExpression extends AbstractSimpleExpression<Boolean> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/EqualValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/EqualValueExpression.java
@@ -43,9 +43,7 @@ public class EqualValueExpression<T extends Number> extends AbstractValuesExpres
         super(value, numbers);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number[] numbers) {
         for (Number number : numbers) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/GreaterOrEqualsValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/GreaterOrEqualsValueExpression.java
@@ -43,9 +43,7 @@ public class GreaterOrEqualsValueExpression<T extends Number> extends AbstractVa
         super(value, number);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number number) {
         return actualValue.doubleValue() >= number.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/GreaterValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/GreaterValueExpression.java
@@ -43,9 +43,7 @@ public class GreaterValueExpression<T extends Number> extends AbstractValueExpre
         super(value, number);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number number) {
         return actualValue.doubleValue() > number.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/NotBetweenValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/NotBetweenValueExpression.java
@@ -44,9 +44,7 @@ public class NotBetweenValueExpression<T extends Number> extends AbstractBetween
         super(value, min, max);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number min, Number max) {
         return actualValue.doubleValue() < min.doubleValue() || actualValue.doubleValue() > max.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/SmallerOrEqualsValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/SmallerOrEqualsValueExpression.java
@@ -43,9 +43,7 @@ public class SmallerOrEqualsValueExpression<T extends Number> extends AbstractVa
         super(value, number);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number number) {
         return actualValue.doubleValue() <= number.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/SmallerValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/SmallerValueExpression.java
@@ -43,9 +43,7 @@ public class SmallerValueExpression<T extends Number> extends AbstractValueExpre
         super(value, number);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number number) {
         return actualValue.doubleValue() < number.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/UnEqualExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/UnEqualExpression.java
@@ -46,16 +46,15 @@ public class UnEqualExpression extends AbstractSimpleExpression<Boolean> {
      * @param value a {@link net.sf.dynamicreports.report.definition.DRIValue} object.
      * @param values a T object.
      * @param <T> a T object.
-     */ public <T> UnEqualExpression(DRIValue<T> value, T... values) {
+     */
+    public <T> UnEqualExpression(DRIValue<T> value, T... values) {
         Validate.notNull(value, "value must not be null");
         Validate.noNullElements(values, "values must not contains null value");
         this.value = value;
         this.values = values;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         Object actualValue = reportParameters.getValue(value);
@@ -67,9 +66,7 @@ public class UnEqualExpression extends AbstractSimpleExpression<Boolean> {
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<Boolean> getValueClass() {
         return Boolean.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/UnEqualValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/condition/UnEqualValueExpression.java
@@ -43,9 +43,7 @@ public class UnEqualValueExpression<T extends Number> extends AbstractValuesExpr
         super(value, numbers);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Boolean compare(Number actualValue, Number[] numbers) {
         for (Number number : numbers) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/AbstractCrosstabGroupBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/AbstractCrosstabGroupBuilder.java
@@ -391,9 +391,7 @@ public abstract class AbstractCrosstabGroupBuilder<T extends AbstractCrosstabGro
         return (T) this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getObject().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/CrosstabMeasureBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/CrosstabMeasureBuilder.java
@@ -354,9 +354,7 @@ public class CrosstabMeasureBuilder<T> extends AbstractBuilder<CrosstabMeasureBu
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return build().getExpression().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/CrosstabVariableBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/crosstab/CrosstabVariableBuilder.java
@@ -81,9 +81,7 @@ public class CrosstabVariableBuilder<T> extends AbstractBuilder<CrosstabVariable
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getObject().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BigDecimalType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BigDecimalType.java
@@ -36,25 +36,19 @@ import java.math.BigDecimal;
 public class BigDecimalType extends NumberType<BigDecimal> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getBigDecimalType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getBigDecimalType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigDecimal numberToValue(Number number) {
         return new BigDecimal(number.doubleValue());

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BigIntegerType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BigIntegerType.java
@@ -36,25 +36,19 @@ import java.math.BigInteger;
 public class BigIntegerType extends NumberType<BigInteger> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getBigIntegerType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getBigIntegerType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigInteger numberToValue(Number number) {
         return BigInteger.valueOf(number.longValue());

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BooleanType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/BooleanType.java
@@ -38,25 +38,19 @@ import java.util.Locale;
 public class BooleanType extends AbstractDataType<Boolean, Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getBooleanType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getBooleanType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean stringToValue(String value, Locale locale) throws DRException {
         return new Boolean(value);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ByteType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ByteType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class ByteType extends NumberType<Byte> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getByteType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getByteType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Byte numberToValue(Number number) {
         return number.byteValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/CharacterType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/CharacterType.java
@@ -39,25 +39,19 @@ import java.util.Locale;
 public class CharacterType extends AbstractDataType<Character, Character> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getCharacterType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getCharacterType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Character stringToValue(String value, Locale locale) throws DRException {
         if (StringUtils.isNotEmpty(value)) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DataTypeBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DataTypeBuilders.java
@@ -37,7 +37,6 @@ public class DataTypeBuilders {
      *
      * @param dataType a {@link java.lang.Class} object.
      * @param <U>      a U object.
-     * @param <T>      a T object.
      * @return a T object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
      */
@@ -49,7 +48,6 @@ public class DataTypeBuilders {
      * <p>detectType.</p>
      *
      * @param dataType a {@link java.lang.String} object.
-     * @param <T>      a T object.
      * @return a T object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
      */

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DataTypes.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DataTypes.java
@@ -68,7 +68,6 @@ public class DataTypes {
      *
      * @param dataType a {@link java.lang.Class} object.
      * @param <U>      a U object.
-     * @param <T>      a T object.
      * @return a T object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
      */
@@ -80,7 +79,6 @@ public class DataTypes {
      * <p>detectType.</p>
      *
      * @param dataType a {@link java.lang.String} object.
-     * @param <T>      a T object.
      * @return a T object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
      */

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateDayType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateDayType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateDayType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateDayType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateDayType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateMonthType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateMonthType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateMonthType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateMonthType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateMonthType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateType.java
@@ -41,25 +41,19 @@ import java.util.Locale;
 public class DateType extends AbstractDataType<Date, Date> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String valueToString(Date value, Locale locale) {
         if (value != null) {
@@ -68,9 +62,7 @@ public class DateType extends AbstractDataType<Date, Date> {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Date stringToValue(String value, Locale locale) throws DRException {
         if (value != null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToFractionType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToFractionType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearToFractionType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearToFractionType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearToFractionType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToHourType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToHourType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearToHourType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearToHourType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearToHourType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToMinuteType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToMinuteType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearToMinuteType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearToMinuteType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearToMinuteType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToMonthType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToMonthType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearToMonthType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearToMonthType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearToMonthType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToSecondType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearToSecondType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearToSecondType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearToSecondType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearToSecondType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DateYearType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DateYearType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDateYearType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDateYearType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DoubleType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/DoubleType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class DoubleType extends NumberType<Double> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getDoubleType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getDoubleType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Double numberToValue(Number number) {
         return number.doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/FloatType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/FloatType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class FloatType extends NumberType<Float> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getFloatType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getFloatType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Float numberToValue(Number number) {
         return number.floatValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/IntegerType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/IntegerType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class IntegerType extends NumberType<Integer> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getIntegerType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getIntegerType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Integer numberToValue(Number number) {
         return number.intValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ListType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ListType.java
@@ -43,25 +43,19 @@ public class ListType extends AbstractDataType<List, List> {
 
     private static ListFormatter listFormatter = new ListFormatter();
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIValueFormatter<?, ? extends List> getValueFormatter() {
         return listFormatter;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getStringType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getStringType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/LongType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/LongType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class LongType extends NumberType<Long> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getLongType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getLongType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Long numberToValue(Number number) {
         return number.longValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/NumberType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/NumberType.java
@@ -40,9 +40,7 @@ import java.util.Locale;
 public abstract class NumberType<T extends Number> extends AbstractDataType<Number, T> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String valueToString(Number value, Locale locale) {
         if (value != null) {
@@ -51,9 +49,7 @@ public abstract class NumberType<T extends Number> extends AbstractDataType<Numb
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T stringToValue(String value, Locale locale) throws DRException {
         if (value != null) {
@@ -74,9 +70,7 @@ public abstract class NumberType<T extends Number> extends AbstractDataType<Numb
      */
     protected abstract T numberToValue(Number number);
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
     public Class<T> getValueClass() {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/PercentageType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/PercentageType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class PercentageType extends DoubleType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getPercentageType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getPercentageType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ShortType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/ShortType.java
@@ -34,25 +34,19 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class ShortType extends NumberType<Short> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getShortType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getShortType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected Short numberToValue(Number number) {
         return number.shortValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/StringType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/StringType.java
@@ -38,25 +38,19 @@ import java.util.Locale;
 public class StringType extends AbstractDataType<String, String> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getStringType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getStringType().getHorizontalTextAlignment();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String stringToValue(String value, Locale locale) throws DRException {
         return value;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToFractionType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToFractionType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class TimeHourToFractionType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getTimeHourToFractionType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getTimeHourToFractionType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToMinuteType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToMinuteType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class TimeHourToMinuteType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getTimeHourToMinuteType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getTimeHourToMinuteType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToSecondType.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/datatype/TimeHourToSecondType.java
@@ -34,17 +34,13 @@ import net.sf.dynamicreports.report.defaults.Defaults;
 public class TimeHourToSecondType extends DateType {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getPattern() {
         return Defaults.getDefaults().getTimeHourToSecondType().getPattern();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public HorizontalTextAlignment getHorizontalTextAlignment() {
         return Defaults.getDefaults().getTimeHourToSecondType().getHorizontalTextAlignment();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AbstractComplexExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AbstractComplexExpression.java
@@ -57,9 +57,7 @@ public abstract class AbstractComplexExpression<T> implements DRIComplexExpressi
         this.expressions = new ArrayList<DRIExpression<?>>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -136,26 +134,20 @@ public abstract class AbstractComplexExpression<T> implements DRIComplexExpressi
         this.expressions.add(Expressions.crosstabValue(crosstabMeasure));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public List<DRIExpression<?>> getExpressions() {
         return expressions;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Class<? super T> getValueClass() {
         return (Class<? super T>) ReportUtils.getGenericClass(this, 0);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public abstract T evaluate(List<?> values, ReportParameters reportParameters);
 }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AbstractSubDatasourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AbstractSubDatasourceExpression.java
@@ -58,18 +58,14 @@ public abstract class AbstractSubDatasourceExpression<T> extends AbstractComplex
         addExpression(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
     public JRDataSource evaluate(List<?> values, ReportParameters reportParameters) {
         return createSubDatasource((T) values.get(0));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super JRDataSource> getValueClass() {
         return JRDataSource.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AddExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/AddExpression.java
@@ -40,13 +40,12 @@ public class AddExpression extends CalculationExpression {
      * <p>Constructor for AddExpression.</p>
      *
      * @param expressions a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     */ public AddExpression(DRIExpression<? extends Number>... expressions) {
+     */
+    public AddExpression(DRIExpression<? extends Number>... expressions) {
         super(expressions);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigDecimal calculate(BigDecimal value1, BigDecimal value2) {
         return value1.add(value2);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/BeanArraySubDatasourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/BeanArraySubDatasourceExpression.java
@@ -53,9 +53,7 @@ public class BeanArraySubDatasourceExpression extends AbstractSubDatasourceExpre
         super(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JRDataSource createSubDatasource(Object[] data) {
         return new JRBeanArrayDataSource(data);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/BeanCollectionSubDatasourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/BeanCollectionSubDatasourceExpression.java
@@ -55,9 +55,7 @@ public class BeanCollectionSubDatasourceExpression extends AbstractSubDatasource
         super(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JRDataSource createSubDatasource(Collection<?> data) {
         return new JRBeanCollectionDataSource(data);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/CalculationExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/CalculationExpression.java
@@ -40,7 +40,8 @@ abstract class CalculationExpression extends AbstractComplexExpression<BigDecima
      * <p>Constructor for CalculationExpression.</p>
      *
      * @param expressions a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     */ protected CalculationExpression(DRIExpression<? extends Number>... expressions) {
+     */
+    protected CalculationExpression(DRIExpression<? extends Number>... expressions) {
         Validate.notNull(expressions, "expressions must not be null");
         Validate.noNullElements(expressions, "expressions must not contains null expression");
         for (DRIExpression<? extends Number> expression : expressions) {
@@ -48,9 +49,7 @@ abstract class CalculationExpression extends AbstractComplexExpression<BigDecima
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public BigDecimal evaluate(List<?> values, ReportParameters reportParameters) {
         BigDecimal result = null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ColumnNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ColumnNumberExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class ColumnNumberExpression extends AbstractSimpleExpression<Integer> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer evaluate(ReportParameters reportParameters) {
         return reportParameters.getColumnNumber();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ColumnRowNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ColumnRowNumberExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class ColumnRowNumberExpression extends AbstractSimpleExpression<Integer> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer evaluate(ReportParameters reportParameters) {
         return reportParameters.getColumnRowNumber();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/DataSourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/DataSourceExpression.java
@@ -49,9 +49,7 @@ public class DataSourceExpression extends AbstractSimpleExpression<JRDataSource>
         this.dataSource = dataSource;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public JRDataSource evaluate(ReportParameters reportParameters) {
         if (moveFirst && dataSource != null && dataSource instanceof JRRewindableDataSource) {
@@ -64,9 +62,7 @@ public class DataSourceExpression extends AbstractSimpleExpression<JRDataSource>
         return dataSource;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<JRDataSource> getValueClass() {
         return JRDataSource.class;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/DivideExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/DivideExpression.java
@@ -43,14 +43,13 @@ public class DivideExpression extends CalculationExpression {
      *
      * @param scale a int.
      * @param expressions a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     */ public DivideExpression(int scale, DRIExpression<? extends Number>... expressions) {
+     */
+    public DivideExpression(int scale, DRIExpression<? extends Number>... expressions) {
         super(expressions);
         this.scale = scale;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigDecimal calculate(BigDecimal value1, BigDecimal value2) {
         return value1.divide(value2, scale, BigDecimal.ROUND_HALF_UP);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ExpressionBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ExpressionBuilders.java
@@ -215,6 +215,7 @@ public class ExpressionBuilders {
      *
      * @param value      a T object.
      * @param valueClass a {@link java.lang.Class} object.
+     * @param valueClass a {@link java.lang.Class} object.
      * @param <T>        a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.expression.ValueExpression} object.
      */

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/Expressions.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/Expressions.java
@@ -227,6 +227,7 @@ public class Expressions {
      *
      * @param value      a T object.
      * @param valueClass a {@link java.lang.Class} object.
+     * @param valueClass a {@link java.lang.Class} object.
      * @param <T>        a T object.
      * @return a {@link net.sf.dynamicreports.report.builder.expression.ValueExpression} object.
      */

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/GroupRowNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/GroupRowNumberExpression.java
@@ -45,9 +45,7 @@ public class GroupRowNumberExpression extends AbstractSimpleExpression<Integer> 
         this.groupName = groupName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer evaluate(ReportParameters reportParameters) {
         return reportParameters.getGroupCount(groupName);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/JasperExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/JasperExpression.java
@@ -53,25 +53,19 @@ public class JasperExpression<T> implements DRIJasperExpression<T> {
         this.name = ReportUtils.generateUniqueName("jasperExpression");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getExpression() {
         return expression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return valueClass;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MapArraySubDatasourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MapArraySubDatasourceExpression.java
@@ -53,9 +53,7 @@ public class MapArraySubDatasourceExpression extends AbstractSubDatasourceExpres
         super(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JRDataSource createSubDatasource(Object[] data) {
         return new JRMapArrayDataSource(data);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MapCollectionSubDatasourceExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MapCollectionSubDatasourceExpression.java
@@ -56,9 +56,7 @@ public class MapCollectionSubDatasourceExpression extends AbstractSubDatasourceE
         super(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected JRDataSource createSubDatasource(Collection<Map<String, ?>> data) {
         return new JRMapCollectionDataSource(data);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MessageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MessageExpression.java
@@ -57,9 +57,7 @@ public class MessageExpression extends AbstractSimpleExpression<String> {
         this.arguments = arguments;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(ReportParameters reportParameters) {
         return reportParameters.getMessage(key, arguments);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MultiplyExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/MultiplyExpression.java
@@ -40,13 +40,12 @@ public class MultiplyExpression extends CalculationExpression {
      * <p>Constructor for MultiplyExpression.</p>
      *
      * @param expressions a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     */ public MultiplyExpression(DRIExpression<? extends Number>... expressions) {
+     */
+    public MultiplyExpression(DRIExpression<? extends Number>... expressions) {
         super(expressions);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigDecimal calculate(BigDecimal value1, BigDecimal value2) {
         return value1.multiply(value2);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/OrderByExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/OrderByExpression.java
@@ -46,9 +46,7 @@ public class OrderByExpression extends AbstractSimpleExpression<Comparable<?>> {
         this.measure = measure;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Comparable<?> evaluate(ReportParameters reportParameters) {
         return reportParameters.getValue(measure);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PageRowNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PageRowNumberExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class PageRowNumberExpression extends AbstractSimpleExpression<Integer> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer evaluate(ReportParameters reportParameters) {
         return reportParameters.getPageRowNumber();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ParameterExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ParameterExpression.java
@@ -51,9 +51,7 @@ public class ParameterExpression implements DRIParameterExpression {
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -68,9 +66,7 @@ public class ParameterExpression implements DRIParameterExpression {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<?> getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PercentageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PercentageExpression.java
@@ -47,9 +47,7 @@ public class PercentageExpression extends AbstractComplexExpression<Double> {
         addExpression(totalExpression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Double evaluate(List<?> values, ReportParameters reportParameters) {
         return ((Number) values.get(0)).doubleValue() / ((Number) values.get(1)).doubleValue();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInEvenRowExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInEvenRowExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class PrintInEvenRowExpression extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getReportRowNumber().doubleValue() % 2 != 0;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInFirstPageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInFirstPageExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class PrintInFirstPageExpression extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getPageNumber() == 1;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInOddRowExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintInOddRowExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class PrintInOddRowExpression extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getReportRowNumber().doubleValue() % 2 == 0;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintNotInFirstPageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintNotInFirstPageExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class PrintNotInFirstPageExpression extends AbstractSimpleExpression<Boolean> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getPageNumber() > 1;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintWhenGroupHasMoreThanOneRowExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PrintWhenGroupHasMoreThanOneRowExpression.java
@@ -45,9 +45,7 @@ public class PrintWhenGroupHasMoreThanOneRowExpression extends AbstractSimpleExp
         this.groupName = groupName;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Boolean evaluate(ReportParameters reportParameters) {
         return reportParameters.getGroupCount(groupName) > 1;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PropertyExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/PropertyExpression.java
@@ -51,9 +51,7 @@ public class PropertyExpression implements DRIPropertyExpression {
         this.valueExpression = valueExpression;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
@@ -68,9 +66,7 @@ public class PropertyExpression implements DRIPropertyExpression {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRIExpression<String> getValueExpression() {
         return valueExpression;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ReportRowNumberExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ReportRowNumberExpression.java
@@ -34,9 +34,7 @@ import net.sf.dynamicreports.report.definition.ReportParameters;
 public class ReportRowNumberExpression extends AbstractSimpleExpression<Integer> {
     private static final long serialVersionUID = Constants.SERIAL_VERSION_UID;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Integer evaluate(ReportParameters reportParameters) {
         return reportParameters.getReportRowNumber();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/SubtractExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/SubtractExpression.java
@@ -40,13 +40,12 @@ public class SubtractExpression extends CalculationExpression {
      * <p>Constructor for SubtractExpression.</p>
      *
      * @param expressions a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     */ public SubtractExpression(DRIExpression<? extends Number>... expressions) {
+     */
+    public SubtractExpression(DRIExpression<? extends Number>... expressions) {
         super(expressions);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected BigDecimal calculate(BigDecimal value1, BigDecimal value2) {
         return value1.subtract(value2);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/SystemMessageExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/SystemMessageExpression.java
@@ -47,9 +47,7 @@ public class SystemMessageExpression extends AbstractSimpleExpression<String> {
         this.key = key;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String evaluate(ReportParameters reportParameters) {
         return ResourceBundle.getBundle(Constants.RESOURCE_BUNDLE_NAME, reportParameters.getLocale()).getString(key);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ValueExpression.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/expression/ValueExpression.java
@@ -43,7 +43,8 @@ public class ValueExpression<T> extends AbstractSimpleExpression<T> {
      * <p>Constructor for ValueExpression.</p>
      *
      * @param value a T object.
-     */ public ValueExpression(T value) {
+     */
+    public ValueExpression(T value) {
         Validate.notNull(value, "value must not be null");
         this.value = value;
         this.valueClass = (Class<? super T>) value.getClass();
@@ -54,6 +55,7 @@ public class ValueExpression<T> extends AbstractSimpleExpression<T> {
      *
      * @param value      a T object.
      * @param valueClass a {@link java.lang.Class} object.
+     * @param valueClass a {@link java.lang.Class} object.
      */
     public ValueExpression(T value, Class<? super T> valueClass) {
         Validate.notNull(valueClass, "valueClass must not be null");
@@ -61,17 +63,13 @@ public class ValueExpression<T> extends AbstractSimpleExpression<T> {
         this.valueClass = valueClass;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public T evaluate(ReportParameters reportParameters) {
         return value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass() {
         return valueClass;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/grid/ColumnTitleGroupBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/grid/ColumnTitleGroupBuilder.java
@@ -104,7 +104,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param columns the number of preferred columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleColumns(Integer columns) {
         getObject().setTitleColumns(columns);
@@ -116,7 +116,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param columns the number of fixed columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleFixedColumns(Integer columns) {
         getObject().setTitleColumns(columns);
@@ -129,7 +129,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param columns the number of minimum columns >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>columns</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>columns</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleMinColumns(Integer columns) {
         getObject().setTitleColumns(columns);
@@ -142,7 +142,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param width the column title preferred width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleWidth(Integer width) {
@@ -155,7 +155,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param width the column title fixed width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleFixedWidth(Integer width) {
@@ -169,7 +169,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param width the column title minimum width >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleMinWidth(Integer width) {
@@ -183,7 +183,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param rows the number of preferred rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -195,7 +195,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param rows the number of fixed rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleFixedRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -208,7 +208,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param rows the number of minimum rows >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>rows</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>rows</code> is < 0
      */
     public ColumnTitleGroupBuilder setTitleMinRows(Integer rows) {
         getObject().setTitleRows(rows);
@@ -221,7 +221,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param height the column title preferred height >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleHeight(Integer height) {
@@ -234,7 +234,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param height the column title fixed height >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleFixedHeight(Integer height) {
@@ -248,7 +248,7 @@ public class ColumnTitleGroupBuilder extends AbstractBuilder<ColumnTitleGroupBui
      *
      * @param height the column title minimum height >= 0
      * @return a {@link net.sf.dynamicreports.report.builder.grid.ColumnTitleGroupBuilder} object.
-     * @throws IllegalArgumentException if <code>height</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>height</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public ColumnTitleGroupBuilder setTitleMinHeight(Integer height) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/grid/HorizontalFlowColumnGridListBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/grid/HorizontalFlowColumnGridListBuilder.java
@@ -38,9 +38,7 @@ public class HorizontalFlowColumnGridListBuilder extends HorizontalColumnGridLis
     protected HorizontalFlowColumnGridListBuilder() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void init() {
         newFlowRow();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/group/ColumnGroupBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/group/ColumnGroupBuilder.java
@@ -86,9 +86,7 @@ public class ColumnGroupBuilder extends GroupBuilder<ColumnGroupBuilder> {
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         setValueExpression(column);

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/group/GroupBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/group/GroupBuilder.java
@@ -519,9 +519,7 @@ public abstract class GroupBuilder<T extends GroupBuilder<T>> extends AbstractBu
         return addFooterComponent(components);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         super.configure();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/BaseStyleBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/BaseStyleBuilder.java
@@ -248,7 +248,8 @@ public abstract class BaseStyleBuilder<T extends BaseStyleBuilder<T, U>, U exten
      *
      * @param pdfEmbedded a {@link java.lang.Boolean} object.
      * @return a T object.
-     */ public T setPdfEmbedded(Boolean pdfEmbedded) {
+     */
+    public T setPdfEmbedded(Boolean pdfEmbedded) {
         getObject().getFont().setPdfEmbedded(pdfEmbedded);
         return (T) this;
     }
@@ -259,7 +260,8 @@ public abstract class BaseStyleBuilder<T extends BaseStyleBuilder<T, U>, U exten
      *
      * @param pdfEncoding a {@link java.lang.String} object.
      * @return a T object.
-     */ public T setPdfEncoding(String pdfEncoding) {
+     */
+    public T setPdfEncoding(String pdfEncoding) {
         getObject().getFont().setPdfEncoding(pdfEncoding);
         return (T) this;
     }
@@ -270,7 +272,8 @@ public abstract class BaseStyleBuilder<T extends BaseStyleBuilder<T, U>, U exten
      *
      * @param pdfFontName a {@link java.lang.String} object.
      * @return a T object.
-     */ public T setPdfFontName(String pdfFontName) {
+     */
+    public T setPdfFontName(String pdfFontName) {
         getObject().getFont().setPdfFontName(pdfFontName);
         return (T) this;
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/FontBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/FontBuilder.java
@@ -131,7 +131,8 @@ public class FontBuilder extends AbstractBuilder<FontBuilder, DRFont> {
      *
      * @param pdfEmbedded a {@link java.lang.Boolean} object.
      * @return a {@link net.sf.dynamicreports.report.builder.style.FontBuilder} object.
-     */ public FontBuilder setPdfEmbedded(Boolean pdfEmbedded) {
+     */
+    public FontBuilder setPdfEmbedded(Boolean pdfEmbedded) {
         getObject().setPdfEmbedded(pdfEmbedded);
         return this;
     }
@@ -142,7 +143,8 @@ public class FontBuilder extends AbstractBuilder<FontBuilder, DRFont> {
      *
      * @param pdfEncoding a {@link java.lang.String} object.
      * @return a {@link net.sf.dynamicreports.report.builder.style.FontBuilder} object.
-     */ public FontBuilder setPdfEncoding(String pdfEncoding) {
+     */
+    public FontBuilder setPdfEncoding(String pdfEncoding) {
         getObject().setPdfEncoding(pdfEncoding);
         return this;
     }
@@ -153,7 +155,8 @@ public class FontBuilder extends AbstractBuilder<FontBuilder, DRFont> {
      *
      * @param pdfFontName a {@link java.lang.String} object.
      * @return a {@link net.sf.dynamicreports.report.builder.style.FontBuilder} object.
-     */ public FontBuilder setPdfFontName(String pdfFontName) {
+     */
+    public FontBuilder setPdfFontName(String pdfFontName) {
         getObject().setPdfFontName(pdfFontName);
         return this;
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/TemplateStyleBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/style/TemplateStyleBuilder.java
@@ -43,9 +43,7 @@ public class TemplateStyleBuilder extends AbstractBuilder<TemplateStyleBuilder, 
         super(new DRTemplateStyle(name));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public DRTemplateStyle getStyle() {
         return build();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/AggregationSubtotalBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/AggregationSubtotalBuilder.java
@@ -124,9 +124,7 @@ public class AggregationSubtotalBuilder<T> extends SubtotalBuilder<AggregationSu
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         DRVariable<T> subtotalVariable = new DRVariable<T>(expression, calculation);
@@ -138,9 +136,7 @@ public class AggregationSubtotalBuilder<T> extends SubtotalBuilder<AggregationSu
         super.configure();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getSubtotal().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/BaseSubtotalBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/BaseSubtotalBuilder.java
@@ -132,7 +132,7 @@ public abstract class BaseSubtotalBuilder<T extends BaseSubtotalBuilder<T, U>, U
      *
      * @param width the label component preferred width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setLabelWidth(Integer width) {
@@ -145,7 +145,7 @@ public abstract class BaseSubtotalBuilder<T extends BaseSubtotalBuilder<T, U>, U
      *
      * @param width the label component fixed width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setLabelFixedWidth(Integer width) {
@@ -159,7 +159,7 @@ public abstract class BaseSubtotalBuilder<T extends BaseSubtotalBuilder<T, U>, U
      *
      * @param width the label component minimum width >= 0
      * @return a T object.
-     * @throws IllegalArgumentException if <code>width</code> is < 0
+     * @throws java.lang.IllegalArgumentException if <code>width</code> is < 0
      * @see net.sf.dynamicreports.report.builder.Units
      */
     public T setLabelMinWidth(Integer width) {
@@ -383,9 +383,7 @@ public abstract class BaseSubtotalBuilder<T extends BaseSubtotalBuilder<T, U>, U
         return (T) this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         super.configure();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/CustomSubtotalBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/CustomSubtotalBuilder.java
@@ -46,9 +46,7 @@ public class CustomSubtotalBuilder<T> extends SubtotalBuilder<CustomSubtotalBuil
         setValueExpression(expression);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return getSubtotal().getName();

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/PercentageSubtotalBuilder.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/PercentageSubtotalBuilder.java
@@ -112,9 +112,7 @@ public class PercentageSubtotalBuilder extends BaseSubtotalBuilder<PercentageSub
         return this;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     protected void configure() {
         if (getObject().getValueField().getDataType() == null) {

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/SubtotalBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/SubtotalBuilders.java
@@ -36,563 +36,198 @@ import net.sf.dynamicreports.report.definition.expression.DRIExpression;
 public class SubtotalBuilders {
 
     // calculation
-
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param calculation    a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> aggregate(ValueColumnBuilder<?, ?> subtotalColumn, Calculation calculation) {
         return Subtotals.aggregate(subtotalColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> aggregate(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         return Subtotals.aggregate(fieldName, valueClass, showInColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> aggregate(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         return Subtotals.aggregate(field, showInColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> aggregate(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         return Subtotals.aggregate(expression, showInColumn, calculation);
     }
 
     // sum
-
-    /**
-     * <p>sum.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<T> sum(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.sum(subtotalColumn);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<T> sum(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.sum(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<T> sum(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.sum(field, showInColumn);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<T> sum(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.sum(expression, showInColumn);
     }
 
     // average
-
-    /**
-     * <p>avg.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> avg(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.avg(subtotalColumn);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> avg(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.avg(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> avg(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.avg(field, showInColumn);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> avg(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.avg(expression, showInColumn);
     }
 
     // count
-
-    /**
-     * <p>count.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> count(ValueColumnBuilder<?, ?> subtotalColumn) {
         return Subtotals.count(subtotalColumn);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> count(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.count(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> count(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.count(field, showInColumn);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> count(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.count(expression, showInColumn);
     }
 
     // distinct count
-
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> distinctCount(ValueColumnBuilder<?, ?> subtotalColumn) {
         return Subtotals.distinctCount(subtotalColumn);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> distinctCount(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.distinctCount(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> distinctCount(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.distinctCount(field, showInColumn);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<Long> distinctCount(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.distinctCount(expression, showInColumn);
     }
 
     // first
-
-    /**
-     * <p>first.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> first(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.first(subtotalColumn);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> first(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.first(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> first(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.first(field, showInColumn);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> first(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.first(expression, showInColumn);
     }
 
     // highest
-
-    /**
-     * <p>max.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> max(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.max(subtotalColumn);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> max(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.max(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> max(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.max(field, showInColumn);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> max(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.max(expression, showInColumn);
     }
 
     // lowest
-
-    /**
-     * <p>min.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> min(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.min(subtotalColumn);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> min(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.min(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> min(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.min(field, showInColumn);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T> AggregationSubtotalBuilder<T> min(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.min(expression, showInColumn);
     }
 
     // standard deviation
-
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> stdDev(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.stdDev(subtotalColumn);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> stdDev(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.stdDev(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> stdDev(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.stdDev(field, showInColumn);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> stdDev(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.stdDev(expression, showInColumn);
     }
 
     // variance
-
-    /**
-     * <p>var.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> var(ValueColumnBuilder<?, T> subtotalColumn) {
         return Subtotals.var(subtotalColumn);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> var(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.var(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> var(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.var(field, showInColumn);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public <T extends Number> AggregationSubtotalBuilder<Number> var(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.var(expression, showInColumn);
     }
 
     // custom
-
-    /**
-     * <p>customValue.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.CustomSubtotalBuilder} object.
-     */
     public <T> CustomSubtotalBuilder<T> customValue(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.customValue(expression, showInColumn);
     }
 
     // percentage
-
-    /**
-     * <p>percentage.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public PercentageSubtotalBuilder percentage(ValueColumnBuilder<?, ? extends Number> subtotalColumn) {
         return Subtotals.percentage(subtotalColumn);
     }
 
-    /**
-     * <p>percentage.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public PercentageSubtotalBuilder percentage(String fieldName, Class<? extends Number> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.percentage(fieldName, valueClass, showInColumn);
     }
 
-    /**
-     * <p>percentage.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public PercentageSubtotalBuilder percentage(FieldBuilder<? extends Number> field, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.percentage(field, showInColumn);
     }
 
     /*public PercentageSubtotalBuilder percentage(DRISimpleExpression<? extends Number> expression, ColumnBuilder<?, ?> showInColumn) {
-       return Subtotals.percentage(expression, showInColumn);
+        return Subtotals.percentage(expression, showInColumn);
     }*/
 
     // text
-
-    /**
-     * <p>text.</p>
-     *
-     * @param text         a {@link java.lang.String} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public AggregationSubtotalBuilder<String> text(String text, ColumnBuilder<?, ?> showInColumn) {
         return Subtotals.text(text, showInColumn);
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/SubtotalBuilders.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/SubtotalBuilders.java
@@ -580,9 +580,9 @@ public class SubtotalBuilders {
         return Subtotals.percentage(field, showInColumn);
     }
 
-	/*public PercentageSubtotalBuilder percentage(DRISimpleExpression<? extends Number> expression, ColumnBuilder<?, ?> showInColumn) {
-		return Subtotals.percentage(expression, showInColumn);
-	}*/
+    /*public PercentageSubtotalBuilder percentage(DRISimpleExpression<? extends Number> expression, ColumnBuilder<?, ?> showInColumn) {
+       return Subtotals.percentage(expression, showInColumn);
+    }*/
 
     // text
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/Subtotals.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/Subtotals.java
@@ -589,10 +589,10 @@ public class Subtotals {
         return new PercentageSubtotalBuilder(field, showInColumn);
     }
 
-	/*public static PercentageSubtotalBuilder percentage(DRISimpleExpression<? extends Number> expression, ColumnBuilder<?, ?> showInColumn) {
-		Validate.notNull(showInColumn, "showInColumn must not be null");
-		return new PercentageSubtotalBuilder(expression, showInColumn);
-	}*/
+    /*public static PercentageSubtotalBuilder percentage(DRISimpleExpression<? extends Number> expression, ColumnBuilder<?, ?> showInColumn) {
+        Validate.notNull(showInColumn, "showInColumn must not be null");
+        return new PercentageSubtotalBuilder(expression, showInColumn);
+    }*/
 
     // text
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/Subtotals.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/subtotal/Subtotals.java
@@ -34,556 +34,198 @@ import org.apache.commons.lang3.Validate;
  * A set of methods of creating column subtotals
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
- * @version $Id: $Id
  */
 public class Subtotals {
 
     // calculation
-
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param calculation    a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> aggregate(ValueColumnBuilder<?, ?> subtotalColumn, Calculation calculation) {
         Validate.notNull(subtotalColumn, "subtotalColumn must not be null");
         return new AggregationSubtotalBuilder<T>(subtotalColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> aggregate(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         return aggregate(DynamicReports.field(fieldName, valueClass), showInColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> aggregate(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         Validate.notNull(showInColumn, "showInColumn must not be null");
         return new AggregationSubtotalBuilder<T>(field, showInColumn, calculation);
     }
 
-    /**
-     * <p>aggregate.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param calculation  a {@link net.sf.dynamicreports.report.constant.Calculation} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> aggregate(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn, Calculation calculation) {
         Validate.notNull(showInColumn, "showInColumn must not be null");
         return new AggregationSubtotalBuilder<T>(expression, showInColumn, calculation);
     }
 
     // sum
-
-    /**
-     * <p>sum.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<T> sum(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.SUM);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<T> sum(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.SUM);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<T> sum(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.SUM);
     }
 
-    /**
-     * <p>sum.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<T> sum(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.SUM);
     }
 
     // average
-
-    /**
-     * <p>avg.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> avg(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.AVERAGE);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> avg(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.AVERAGE);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> avg(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.AVERAGE);
     }
 
-    /**
-     * <p>avg.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> avg(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.AVERAGE);
     }
 
     // count
-
-    /**
-     * <p>count.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> count(ValueColumnBuilder<?, ?> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.COUNT);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> count(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.COUNT);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> count(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.COUNT);
     }
 
-    /**
-     * <p>count.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> count(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.COUNT);
     }
 
     // distinct count
-
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> distinctCount(ValueColumnBuilder<?, ?> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.DISTINCT_COUNT);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> distinctCount(String fieldName, Class<?> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.DISTINCT_COUNT);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> distinctCount(FieldBuilder<?> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.DISTINCT_COUNT);
     }
 
-    /**
-     * <p>distinctCount.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<Long> distinctCount(DRIExpression<?> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.DISTINCT_COUNT);
     }
 
     // first
-
-    /**
-     * <p>first.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> first(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.FIRST);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> first(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.FIRST);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> first(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.FIRST);
     }
 
-    /**
-     * <p>first.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> first(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.FIRST);
     }
 
     // highest
-
-    /**
-     * <p>max.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> max(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.HIGHEST);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> max(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.HIGHEST);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> max(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.HIGHEST);
     }
 
-    /**
-     * <p>max.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> max(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.HIGHEST);
     }
 
     // lowest
-
-    /**
-     * <p>min.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> min(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.LOWEST);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> min(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.LOWEST);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> min(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.LOWEST);
     }
 
-    /**
-     * <p>min.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T> AggregationSubtotalBuilder<T> min(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.LOWEST);
     }
 
     // standard deviation
-
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> stdDev(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.STANDARD_DEVIATION);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> stdDev(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.STANDARD_DEVIATION);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> stdDev(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.STANDARD_DEVIATION);
     }
 
-    /**
-     * <p>stdDev.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> stdDev(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.STANDARD_DEVIATION);
     }
 
     // variance
-
-    /**
-     * <p>var.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @param <T>            a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> var(ValueColumnBuilder<?, T> subtotalColumn) {
         return aggregate(subtotalColumn, Calculation.VARIANCE);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> var(String fieldName, Class<T> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(fieldName, valueClass, showInColumn, Calculation.VARIANCE);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> var(FieldBuilder<T> field, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(field, showInColumn, Calculation.VARIANCE);
     }
 
-    /**
-     * <p>var.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static <T extends Number> AggregationSubtotalBuilder<Number> var(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(expression, showInColumn, Calculation.VARIANCE);
     }
 
     // custom
-
-    /**
-     * <p>customValue.</p>
-     *
-     * @param expression   a {@link net.sf.dynamicreports.report.definition.expression.DRIExpression} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @param <T>          a T object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.CustomSubtotalBuilder} object.
-     */
     public static <T> CustomSubtotalBuilder<T> customValue(DRIExpression<T> expression, ColumnBuilder<?, ?> showInColumn) {
         Validate.notNull(showInColumn, "showInColumn must not be null");
         return new CustomSubtotalBuilder<T>(expression, showInColumn);
     }
 
     // percentage
-
-    /**
-     * <p>percentage.</p>
-     *
-     * @param subtotalColumn a {@link net.sf.dynamicreports.report.builder.column.ValueColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public static PercentageSubtotalBuilder percentage(ValueColumnBuilder<?, ? extends Number> subtotalColumn) {
         Validate.notNull(subtotalColumn, "subtotalColumn must not be null");
         return new PercentageSubtotalBuilder(subtotalColumn);
     }
 
-    /**
-     * <p>percentage.</p>
-     *
-     * @param fieldName    a {@link java.lang.String} object.
-     * @param valueClass   a {@link java.lang.Class} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public static PercentageSubtotalBuilder percentage(String fieldName, Class<? extends Number> valueClass, ColumnBuilder<?, ?> showInColumn) {
         return percentage(DynamicReports.<Number>field(fieldName, valueClass), showInColumn);
     }
 
-    /**
-     * <p>percentage.</p>
-     *
-     * @param field        a {@link net.sf.dynamicreports.report.builder.FieldBuilder} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.PercentageSubtotalBuilder} object.
-     */
     public static PercentageSubtotalBuilder percentage(FieldBuilder<? extends Number> field, ColumnBuilder<?, ?> showInColumn) {
         Validate.notNull(showInColumn, "showInColumn must not be null");
         return new PercentageSubtotalBuilder(field, showInColumn);
@@ -595,14 +237,6 @@ public class Subtotals {
     }*/
 
     // text
-
-    /**
-     * <p>text.</p>
-     *
-     * @param text         a {@link java.lang.String} object.
-     * @param showInColumn a {@link net.sf.dynamicreports.report.builder.column.ColumnBuilder} object.
-     * @return a {@link net.sf.dynamicreports.report.builder.subtotal.AggregationSubtotalBuilder} object.
-     */
     public static AggregationSubtotalBuilder<String> text(String text, ColumnBuilder<?, ?> showInColumn) {
         return aggregate(Expressions.text(text), showInColumn, Calculation.NOTHING);
     }

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/tableofcontents/TableOfContentsCustomizer.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/builder/tableofcontents/TableOfContentsCustomizer.java
@@ -116,41 +116,31 @@ public class TableOfContentsCustomizer implements DRITableOfContentsCustomizer {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setReport(ReportBuilder<?> report) {
         this.report = report;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setHeadingList(List<JasperTocHeading> headingList) {
         this.headingList = headingList;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setHeadings(int headings) {
         this.headings = headings;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void setLevels(int levels) {
         this.levels = levels;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void customize() {
         init();
@@ -288,9 +278,7 @@ public class TableOfContentsCustomizer implements DRITableOfContentsCustomizer {
         this.pageIndexFixedWidth = pageIndexFixedWidth;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public TableOfContentsPosition getPosition() {
         return position;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/datasource/DRDataSource.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/datasource/DRDataSource.java
@@ -70,17 +70,13 @@ public class DRDataSource implements JRRewindableDataSource, Serializable {
         this.values.add(row);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Object getFieldValue(JRField field) throws JRException {
         return currentRecord.get(field.getName());
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean next() throws JRException {
         if (iterator == null) {
@@ -93,9 +89,7 @@ public class DRDataSource implements JRRewindableDataSource, Serializable {
         return hasNext;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public void moveFirst() throws JRException {
         iterator = null;

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/DRIParameter.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/DRIParameter.java
@@ -31,9 +31,7 @@ import java.io.Serializable;
  */
 public interface DRIParameter<T> extends DRIValue<T>, Serializable {
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName();
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/crosstab/DRICrosstabGroup.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/crosstab/DRICrosstabGroup.java
@@ -43,9 +43,7 @@ import java.util.List;
  */
 public interface DRICrosstabGroup<T> extends DRISystemExpression<T> {
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName();
 

--- a/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/crosstab/DRICrosstabVariable.java
+++ b/dynamicreports-core/src/main/java/net/sf/dynamicreports/report/definition/crosstab/DRICrosstabVariable.java
@@ -35,9 +35,7 @@ import net.sf.dynamicreports.report.definition.expression.DRISystemExpression;
  */
 public interface DRICrosstabVariable<T> extends DRISystemExpression<T>, DRIValue<T> {
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public Class<? super T> getValueClass();
 

--- a/dynamicreports-examples/pom.xml
+++ b/dynamicreports-examples/pom.xml
@@ -88,9 +88,104 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${sourceVersion}</source>
+                    <target>${targetVersion}</target>
+                    <encoding>${encoding}</encoding>
+                </configuration>
+            </plugin>
+            <!--Check for use of legacy code-->
+            <plugin>
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <!--Could run with mvn clean verify-->
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>run-checkstyle</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>module-info.java</excludes>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    <headerLocation>../src/etc/checkstyle.xml</headerLocation>
+                    <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
+                    <configLocation>../src/etc/checkstyle.xml</configLocation>
+                    <consoleOutput>${checkstyle.config.consoleOutput}</consoleOutput>
+                    <failsOnError>${checkstyle.config.failsOnError}</failsOnError>
+                    <includeResources>${checkstyle.config.includeResources}</includeResources>
+                    <includeTestResources>${checkstyle.config.includeTestResources}</includeTestResources>
+                    <includeTestSourceDirectory>${checkstyle.config.includeTestSourceDirectory}</includeTestSourceDirectory>
+                    <linkXRef>${linkXRef}</linkXRef>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <!--// TODO Use javadoc from JAVA 10 to create searcheable javadocs-->
+                    <!--<javadocExecutable>${env.JAVA_10_HOME}\bin\javadoc.exe</javadocExecutable>-->
+                    <sourceFileExcludes>
+                        <sourceFileExclude>${project.basedir}/dynamicreports-core/target</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+            <!--//TODO fix "commandline was too long error"-->
+            <!--<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            &lt;!&ndash;<goal>jdkinternals</goal>&ndash;&gt; &lt;!&ndash; verify main classes &ndash;&gt;
+                            <goal>test-jdkinternals</goal> &lt;!&ndash; verify test classes &ndash;&gt;
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>-->
         </plugins>
     </build>
 

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/adhoc/SimpleAdhocReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/adhoc/SimpleAdhocReport.java
@@ -97,7 +97,7 @@ public class SimpleAdhocReport {
 
     private JRDataSource createDataSource() {
         DRDataSource dataSource = new DRDataSource("item", "orderdate", "quantity", "unitprice");
-        IntStream.range(0, 20).forEach(i -> dataSource.add("Book # "+ i, Date.from(Instant.now()), (int) (Math.random() * 10) + 1, BigDecimal.valueOf(Math.random() * 100 + 1)));
+        IntStream.range(0, 20).forEach(i -> dataSource.add("Book # " + i, Date.from(Instant.now()), (int) (Math.random() * 10) + 1, BigDecimal.valueOf(Math.random() * 100 + 1)));
         return dataSource;
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/column/ColumnDetectDataTypeReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/column/ColumnDetectDataTypeReport.java
@@ -62,7 +62,7 @@ public class ColumnDetectDataTypeReport {
         new ColumnDetectDataTypeReport();
     }
 
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void build() {
         try {
             JasperReportBuilder report = report();
@@ -83,18 +83,18 @@ public class ColumnDetectDataTypeReport {
 
     private List<Column> createColumns() {
         List<Column> columns = new ArrayList<Column>();
-        columns.add(new Column("Item", "item", "string"));// dataType = "String", "STRING", "java.lang.String", "text"
-        columns.add(new Column("Quantity", "quantity", "integer"));// dataType = "Integer", "INTEGER", "java.lang.Integer"
-        columns.add(new Column("Unit price", "unitprice", "bigDecimal"));// dataType = "bigdecimal", "BIGDECIMAL", "java.math.BigDecimal"
-        columns.add(new Column("Order date", "orderdate", "date"));// dataType = "Date", "DATE", "java.util.Date"
-        columns.add(new Column("Order date", "orderdate", "dateYearToFraction"));// dataType = "dateyeartofraction", "DATEYEARTOFRACTION"
-        columns.add(new Column("Order year", "orderdate", "dateYear"));// dataType = "DateYear", "dateyear", "DATEYEAR"
-        columns.add(new Column("Order month", "orderdate", "dateMonth"));// dataType = "DateMonth", "datemonth", "DATEMONTH"
-        columns.add(new Column("Order day", "orderdate", "dateDay"));// dataType = "DateDay", "dateday", "DATEDAY"
+        columns.add(new Column("Item", "item", "string")); // dataType = "String", "STRING", "java.lang.String", "text"
+        columns.add(new Column("Quantity", "quantity", "integer")); // dataType = "Integer", "INTEGER", "java.lang.Integer"
+        columns.add(new Column("Unit price", "unitprice", "bigDecimal")); // dataType = "bigdecimal", "BIGDECIMAL", "java.math.BigDecimal"
+        columns.add(new Column("Order date", "orderdate", "date")); // dataType = "Date", "DATE", "java.util.Date"
+        columns.add(new Column("Order date", "orderdate", "dateYearToFraction")); // dataType = "dateyeartofraction", "DATEYEARTOFRACTION"
+        columns.add(new Column("Order year", "orderdate", "dateYear")); // dataType = "DateYear", "dateyear", "DATEYEAR"
+        columns.add(new Column("Order month", "orderdate", "dateMonth")); // dataType = "DateMonth", "datemonth", "DATEMONTH"
+        columns.add(new Column("Order day", "orderdate", "dateDay")); // dataType = "DateDay", "dateday", "DATEDAY"
         return columns;
     }
 
-    private class Column {
+    private final class Column {
         private String title;
         private String field;
         private String dataType;

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/complex/dynamicreport/DynamicReportDesign.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/complex/dynamicreport/DynamicReportDesign.java
@@ -72,7 +72,7 @@ public class DynamicReportDesign {
      * @return a {@link net.sf.dynamicreports.jasper.builder.JasperReportBuilder} object.
      * @throws net.sf.dynamicreports.report.exception.DRException if any.
      */
-    @SuppressWarnings( {"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public JasperReportBuilder build() throws DRException {
         JasperReportBuilder report = report();
 

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/complex/salestableofcontents/SalesTableOfContentsDesign.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/complex/salestableofcontents/SalesTableOfContentsDesign.java
@@ -189,7 +189,7 @@ public class SalesTableOfContentsDesign {
             return headingComponent;
         }
 
-        private class CountryExpression extends AbstractComplexExpression<String> {
+        private final class CountryExpression extends AbstractComplexExpression<String> {
             private static final long serialVersionUID = 1L;
 
             private String value;
@@ -209,7 +209,7 @@ public class SalesTableOfContentsDesign {
             }
         }
 
-        private class CountryHeadingExpression extends AbstractComplexExpression<String> {
+        private final class CountryHeadingExpression extends AbstractComplexExpression<String> {
             private static final long serialVersionUID = 1L;
 
             private CountryHeadingExpression() {

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/crosstab/CustomPercentageCrosstabReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/crosstab/CustomPercentageCrosstabReport.java
@@ -128,7 +128,7 @@ public class CustomPercentageCrosstabReport {
         return dataSource;
     }
 
-    private class PercentageExpression extends AbstractComplexExpression<BigDecimal> {
+    private final class PercentageExpression extends AbstractComplexExpression<BigDecimal> {
         private static final long serialVersionUID = 1L;
 
         private PercentageExpression(CrosstabMeasureBuilder<BigDecimal> unitPriceMeasure, CrosstabColumnGroupBuilder<String> columnGroup) {

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/BandReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/BandReport.java
@@ -93,7 +93,7 @@ public class BandReport {
                     .background(createTextField("This is a background band").setHeight(800).setStyle(backgroundStyle))
 
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ColumnGrid1Report.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ColumnGrid1Report.java
@@ -40,7 +40,7 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.type;
  * @version $Id: $Id
  */
 public class ColumnGrid1Report {
-    private final int columns_count = 12;
+    private final int columnsCount = 12;
 
     /**
      * <p>Constructor for ColumnGrid1Report.</p>
@@ -59,11 +59,11 @@ public class ColumnGrid1Report {
     }
 
     private void build() {
-        @SuppressWarnings("unchecked") TextColumnBuilder<String>[] columns = new TextColumnBuilder[columns_count];
-        for (int i = 1; i <= columns_count; i++) {
+        @SuppressWarnings("unchecked") TextColumnBuilder<String>[] columns = new TextColumnBuilder[columnsCount];
+        for (int i = 1; i <= columnsCount; i++) {
             columns[i - 1] = col.column("Column" + i, "column" + i, type.stringType());
         }
-        columns[columns_count / 2].setFixedWidth(300);
+        columns[columnsCount / 2].setFixedWidth(300);
 
         try {
             report().setTextStyle(stl.style(stl.pen1Point()))
@@ -78,14 +78,14 @@ public class ColumnGrid1Report {
     }
 
     private JRDataSource createDataSource() {
-        String[] columns = new String[columns_count];
-        for (int i = 1; i <= columns_count; i++) {
+        String[] columns = new String[columnsCount];
+        for (int i = 1; i <= columnsCount; i++) {
             columns[i - 1] = "column" + i;
         }
         DRDataSource dataSource = new DRDataSource(columns);
         for (int i = 1; i <= 5; i++) {
-            Object[] row = new Object[columns_count];
-            for (int j = 0; j < columns_count; j++) {
+            Object[] row = new Object[columnsCount];
+            for (int j = 0; j < columnsCount; j++) {
                 row[j] = "row " + i;
             }
             dataSource.add(row);

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ColumnGrid2Report.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ColumnGrid2Report.java
@@ -40,7 +40,7 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.type;
  * @version $Id: $Id
  */
 public class ColumnGrid2Report {
-    private final int columns_count = 12;
+    private final int columnsCount = 12;
 
     /**
      * <p>Constructor for ColumnGrid2Report.</p>
@@ -59,8 +59,8 @@ public class ColumnGrid2Report {
     }
 
     private void build() {
-        @SuppressWarnings("unchecked") TextColumnBuilder<String>[] columns = new TextColumnBuilder[columns_count];
-        for (int i = 1; i <= columns_count; i++) {
+        @SuppressWarnings("unchecked") TextColumnBuilder<String>[] columns = new TextColumnBuilder[columnsCount];
+        for (int i = 1; i <= columnsCount; i++) {
             columns[i - 1] = col.column("Column" + i, "column" + i, type.stringType());
         }
 
@@ -78,14 +78,14 @@ public class ColumnGrid2Report {
     }
 
     private JRDataSource createDataSource() {
-        String[] columns = new String[columns_count];
-        for (int i = 1; i <= columns_count; i++) {
+        String[] columns = new String[columnsCount];
+        for (int i = 1; i <= columnsCount; i++) {
             columns[i - 1] = "column" + i;
         }
         DRDataSource dataSource = new DRDataSource(columns);
         for (int i = 1; i <= 5; i++) {
-            Object[] row = new Object[columns_count];
-            for (int j = 0; j < columns_count; j++) {
+            Object[] row = new Object[columnsCount];
+            for (int j = 0; j < columnsCount; j++) {
                 row[j] = "row " + i;
             }
             dataSource.add(row);

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ContainerReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/ContainerReport.java
@@ -68,7 +68,7 @@ public class ContainerReport {
                     .title(createTextField("Horizontal list (contains 10 textfields)"), createHorizontalList(), cmp.verticalGap(20),
                            createTextField("Multi row horizontal list (contains 10 textfields)"), createMultiRowHorizontalList(), cmp.verticalGap(20),
                            createTextField("Horizontal flow list (contains 9 textfields)"), createHorizontalFlowList(), cmp.verticalGap(20), createTextField("Vertical list (contains 4 textfields)"),
-                           createVerticalList(), cmp.verticalGap(20), createTextField("Nested list (contains 1 horizontal and 3 vertical lists)"), createNestedList()).show();// create and show report
+                           createVerticalList(), cmp.verticalGap(20), createTextField("Nested list (contains 1 horizontal and 3 vertical lists)"), createNestedList()).show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportClassicSyntax.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportClassicSyntax.java
@@ -38,12 +38,12 @@ import java.math.BigDecimal;
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_ClassicSyntax {
+public class SimpleReportClassicSyntax {
 
     /**
      * <p>Constructor for SimpleReport_ClassicSyntax.</p>
      */
-    public SimpleReport_ClassicSyntax() {
+    public SimpleReportClassicSyntax() {
         build();
     }
 
@@ -53,7 +53,7 @@ public class SimpleReport_ClassicSyntax {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_ClassicSyntax();
+        new SimpleReportClassicSyntax();
     }
 
     private void build() {

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep01.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep01.java
@@ -38,12 +38,12 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.type;
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step01 {
+public class SimpleReportStep01 {
 
     /**
      * <p>Constructor for SimpleReport_Step01.</p>
      */
-    public SimpleReport_Step01() {
+    public SimpleReportStep01() {
         build();
     }
 
@@ -53,7 +53,7 @@ public class SimpleReport_Step01 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step01();
+        new SimpleReportStep01();
     }
 
     private void build() {
@@ -65,7 +65,7 @@ public class SimpleReport_Step01 {
                     .title(cmp.text("Getting started"))// shows report title
                     .pageFooter(cmp.pageXofY())// shows number of page at page footer
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep02.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep02.java
@@ -21,9 +21,6 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
-import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
-import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
-import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
@@ -33,26 +30,24 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
-import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
-import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step06 class.</p>
+ * <p>SimpleReport_Step02 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step06 {
+public class SimpleReportStep02 {
 
     /**
-     * <p>Constructor for SimpleReport_Step06.</p>
+     * <p>Constructor for SimpleReport_Step02.</p>
      */
-    public SimpleReport_Step06() {
+    public SimpleReportStep02() {
         build();
     }
 
@@ -62,41 +57,24 @@ public class SimpleReport_Step06 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step06();
+        new SimpleReportStep02();
     }
 
     private void build() {
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
-
-        // title, field name data type
-        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
-        TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
-        // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
-        PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
-        TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
-                                                        // sets the fixed width of a column, width = 2 * character width
-                                                        .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
-        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
-        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
-                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
-                             rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
-                    .groupBy(itemColumn)
-                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
+                             // title, field name data type
+                             col.column("Item", "item", type.stringType()), col.column("Quantity", "quantity", type.integerType()), col.column("Unit price", "unitprice", type.bigDecimalType()))
                     .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
-                    .summary(itemChart, itemChart2)
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep03.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep03.java
@@ -21,16 +21,10 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
-import net.sf.dynamicreports.examples.Templates;
-import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
-import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
-import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
-import net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
-import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -38,30 +32,24 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
-import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
-import static net.sf.dynamicreports.report.builder.DynamicReports.cnd;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
-import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
-import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
-import static net.sf.dynamicreports.report.builder.DynamicReports.grp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
-import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step12 class.</p>
+ * <p>SimpleReport_Step03 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step12 {
+public class SimpleReportStep03 {
 
     /**
-     * <p>Constructor for SimpleReport_Step12.</p>
+     * <p>Constructor for SimpleReport_Step03.</p>
      */
-    public SimpleReport_Step12() {
+    public SimpleReportStep03() {
         build();
     }
 
@@ -71,61 +59,34 @@ public class SimpleReport_Step12 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step12();
+        new SimpleReportStep03();
     }
 
     private void build() {
-        CurrencyType currencyType = new CurrencyType();
-
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
-        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
-        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
+        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType());
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
-        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
-        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
-        ColumnGroupBuilder itemGroup = grp.group(itemColumn);
-        itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
-
-        ConditionalStyleBuilder condition1 = stl.conditionalStyle(cnd.greater(priceColumn, 150)).setBackgroundColor(new Color(210, 255, 210));
-        ConditionalStyleBuilder condition2 = stl.conditionalStyle(cnd.smaller(priceColumn, 30)).setBackgroundColor(new Color(255, 210, 210));
-        ConditionalStyleBuilder condition3 = stl.conditionalStyle(cnd.greater(priceColumn, 200)).setBackgroundColor(new Color(0, 190, 0)).bold();
-        ConditionalStyleBuilder condition4 = stl.conditionalStyle(cnd.smaller(priceColumn, 20)).setBackgroundColor(new Color(190, 0, 0)).bold();
-        StyleBuilder priceStyle = stl.style().conditionalStyles(condition3, condition4);
-        priceColumn.setStyle(priceStyle);
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
-                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
-                    .columnGrid(rowNumberColumn, quantityColumn, unitPriceColumn, grid.verticalColumnGridList(priceColumn, pricePercColumn))
-                    .groupBy(itemGroup)
-                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .detailRowHighlighters(condition1, condition2)
-                    .title(// shows report title
-                           cmp.horizontalList()
-                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
-                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
-                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
-                              .newRow()
-                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
+                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
-                    .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -142,14 +103,5 @@ public class SimpleReport_Step12 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
-    }
-
-    private class CurrencyType extends BigDecimalType {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public String getPattern() {
-            return "$ #,###.00";
-        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep04.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep04.java
@@ -21,16 +21,10 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
-import net.sf.dynamicreports.examples.Templates;
-import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
-import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
-import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
-import net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
-import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -38,30 +32,24 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
-import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
-import static net.sf.dynamicreports.report.builder.DynamicReports.cnd;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
-import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
-import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
-import static net.sf.dynamicreports.report.builder.DynamicReports.grp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
-import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step11 class.</p>
+ * <p>SimpleReport_Step04 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step11 {
+public class SimpleReportStep04 {
 
     /**
-     * <p>Constructor for SimpleReport_Step11.</p>
+     * <p>Constructor for SimpleReport_Step04.</p>
      */
-    public SimpleReport_Step11() {
+    public SimpleReportStep04() {
         build();
     }
 
@@ -71,57 +59,35 @@ public class SimpleReport_Step11 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step11();
+        new SimpleReportStep04();
     }
 
     private void build() {
-        CurrencyType currencyType = new CurrencyType();
-
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
-        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
-        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
-        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
-        ColumnGroupBuilder itemGroup = grp.group(itemColumn);
-        itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
-
-        ConditionalStyleBuilder condition1 = stl.conditionalStyle(cnd.greater(priceColumn, 150)).setBackgroundColor(new Color(210, 255, 210));
-        ConditionalStyleBuilder condition2 = stl.conditionalStyle(cnd.smaller(priceColumn, 30)).setBackgroundColor(new Color(255, 210, 210));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
-                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
-                    .columnGrid(rowNumberColumn, quantityColumn, unitPriceColumn, grid.verticalColumnGridList(priceColumn, pricePercColumn))
-                    .groupBy(itemGroup)
-                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .detailRowHighlighters(condition1, condition2)
-                    .title(// shows report title
-                           cmp.horizontalList()
-                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
-                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
-                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
-                              .newRow()
-                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
+                    .groupBy(itemColumn)
+                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
-                    .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -138,14 +104,5 @@ public class SimpleReport_Step11 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
-    }
-
-    private class CurrencyType extends BigDecimalType {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public String getPattern() {
-            return "$ #,###.00";
-        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep05.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep05.java
@@ -21,6 +21,8 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
+import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
@@ -33,21 +35,22 @@ import java.math.BigDecimal;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
+import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step02 class.</p>
+ * <p>SimpleReport_Step05 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step02 {
+public class SimpleReportStep05 {
 
     /**
-     * <p>Constructor for SimpleReport_Step02.</p>
+     * <p>Constructor for SimpleReport_Step05.</p>
      */
-    public SimpleReport_Step02() {
+    public SimpleReportStep05() {
         build();
     }
 
@@ -57,24 +60,38 @@ public class SimpleReport_Step02 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step02();
+        new SimpleReportStep05();
     }
 
     private void build() {
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
+
+        // title, field name data type
+        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
+        TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
+        // price = unitPrice * quantity
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
+        PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
+        TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
+                                                        // sets the fixed width of a column, width = 2 * character width
+                                                        .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
+                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
-                             // title, field name data type
-                             col.column("Item", "item", type.stringType()), col.column("Quantity", "quantity", type.integerType()), col.column("Unit price", "unitprice", type.bigDecimalType()))
+                             rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
+                    .groupBy(itemColumn)
+                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
+                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep06.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep06.java
@@ -21,6 +21,7 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
@@ -32,24 +33,26 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
+import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
+import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step04 class.</p>
+ * <p>SimpleReport_Step06 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step04 {
+public class SimpleReportStep06 {
 
     /**
-     * <p>Constructor for SimpleReport_Step04.</p>
+     * <p>Constructor for SimpleReport_Step06.</p>
      */
-    public SimpleReport_Step04() {
+    public SimpleReportStep06() {
         build();
     }
 
@@ -59,7 +62,7 @@ public class SimpleReport_Step04 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step04();
+        new SimpleReportStep06();
     }
 
     private void build() {
@@ -77,17 +80,23 @@ public class SimpleReport_Step04 {
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
+        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
+        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
+                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
                     .groupBy(itemColumn)
+                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
+                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
+                    .summary(itemChart, itemChart2)
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep07.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep07.java
@@ -21,6 +21,7 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
@@ -32,24 +33,27 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
+import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
+import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
+import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step03 class.</p>
+ * <p>SimpleReport_Step07 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step03 {
+public class SimpleReportStep07 {
 
     /**
-     * <p>Constructor for SimpleReport_Step03.</p>
+     * <p>Constructor for SimpleReport_Step07.</p>
      */
-    public SimpleReport_Step03() {
+    public SimpleReportStep07() {
         build();
     }
 
@@ -59,7 +63,7 @@ public class SimpleReport_Step03 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step03();
+        new SimpleReportStep07();
     }
 
     private void build() {
@@ -68,7 +72,7 @@ public class SimpleReport_Step03 {
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
 
         // title, field name data type
-        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType());
+        TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
         TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
         // price = unitPrice * quantity
@@ -77,16 +81,24 @@ public class SimpleReport_Step03 {
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
+        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
+        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
+                    .setSubtotalStyle(boldStyle)
                     .highlightDetailEvenRows()
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
+                    .columnGrid(rowNumberColumn, quantityColumn, unitPriceColumn, grid.verticalColumnGridList(priceColumn, pricePercColumn))
+                    .groupBy(itemColumn)
+                    .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
+                    .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
+                    .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep08.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep08.java
@@ -21,15 +21,12 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
-import net.sf.dynamicreports.examples.Templates;
 import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
-import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
 import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
-import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -49,17 +46,17 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step10 class.</p>
+ * <p>SimpleReport_Step08 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step10 {
+public class SimpleReportStep08 {
 
     /**
-     * <p>Constructor for SimpleReport_Step10.</p>
+     * <p>Constructor for SimpleReport_Step08.</p>
      */
-    public SimpleReport_Step10() {
+    public SimpleReportStep08() {
         build();
     }
 
@@ -69,23 +66,20 @@ public class SimpleReport_Step10 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step10();
+        new SimpleReportStep08();
     }
 
     private void build() {
-        CurrencyType currencyType = new CurrencyType();
-
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
-        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
@@ -105,17 +99,11 @@ public class SimpleReport_Step10 {
                     .groupBy(itemGroup)
                     .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .title(// shows report title
-                           cmp.horizontalList()
-                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
-                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
-                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
-                              .newRow()
-                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
+                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
                     .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -132,14 +120,5 @@ public class SimpleReport_Step10 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
-    }
-
-    private class CurrencyType extends BigDecimalType {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public String getPattern() {
-            return "$ #,###.00";
-        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep09.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep09.java
@@ -21,11 +21,14 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.examples.Templates;
 import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
+import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
+import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -36,24 +39,26 @@ import java.math.BigDecimal;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
+import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
+import static net.sf.dynamicreports.report.builder.DynamicReports.grp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
 import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step07 class.</p>
+ * <p>SimpleReport_Step09 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step07 {
+public class SimpleReportStep09 {
 
     /**
-     * <p>Constructor for SimpleReport_Step07.</p>
+     * <p>Constructor for SimpleReport_Step09.</p>
      */
-    public SimpleReport_Step07() {
+    public SimpleReportStep09() {
         build();
     }
 
@@ -63,13 +68,14 @@ public class SimpleReport_Step07 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step07();
+        new SimpleReportStep09();
     }
 
     private void build() {
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
+        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
@@ -83,6 +89,8 @@ public class SimpleReport_Step07 {
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
+        ColumnGroupBuilder itemGroup = grp.group(itemColumn);
+        itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
@@ -91,14 +99,20 @@ public class SimpleReport_Step07 {
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
                     .columnGrid(rowNumberColumn, quantityColumn, unitPriceColumn, grid.verticalColumnGridList(priceColumn, pricePercColumn))
-                    .groupBy(itemColumn)
+                    .groupBy(itemGroup)
                     .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
+                    .title(// shows report title
+                           cmp.horizontalList()
+                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
+                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
+                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
+                              .newRow()
+                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
                     .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep10.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep10.java
@@ -21,10 +21,15 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.examples.Templates;
+import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
+import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
+import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
+import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -32,25 +37,29 @@ import net.sf.jasperreports.engine.JRDataSource;
 import java.awt.Color;
 import java.math.BigDecimal;
 
+import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
+import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
+import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
+import static net.sf.dynamicreports.report.builder.DynamicReports.grp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.report;
 import static net.sf.dynamicreports.report.builder.DynamicReports.sbt;
 import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step05 class.</p>
+ * <p>SimpleReport_Step10 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step05 {
+public class SimpleReportStep10 {
 
     /**
-     * <p>Constructor for SimpleReport_Step05.</p>
+     * <p>Constructor for SimpleReport_Step10.</p>
      */
-    public SimpleReport_Step05() {
+    public SimpleReportStep10() {
         build();
     }
 
@@ -60,24 +69,31 @@ public class SimpleReport_Step05 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step05();
+        new SimpleReportStep10();
     }
 
     private void build() {
+        CurrencyType currencyType = new CurrencyType();
+
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
+        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
                                                         .setFixedColumns(2).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
+        Bar3DChartBuilder itemChart = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
+        Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
+        ColumnGroupBuilder itemGroup = grp.group(itemColumn);
+        itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
@@ -85,13 +101,21 @@ public class SimpleReport_Step05 {
                     .highlightDetailEvenRows()
                     .columns(// add columns
                              rowNumberColumn, itemColumn, quantityColumn, unitPriceColumn, priceColumn, pricePercColumn)
-                    .groupBy(itemColumn)
+                    .columnGrid(rowNumberColumn, quantityColumn, unitPriceColumn, grid.verticalColumnGridList(priceColumn, pricePercColumn))
+                    .groupBy(itemGroup)
                     .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
+                    .title(// shows report title
+                           cmp.horizontalList()
+                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
+                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
+                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
+                              .newRow()
+                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
+                    .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -108,5 +132,14 @@ public class SimpleReport_Step05 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
+    }
+
+    private class CurrencyType extends BigDecimalType {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getPattern() {
+            return "$ #,###.00";
+        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep11.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep11.java
@@ -21,12 +21,16 @@
  */
 package net.sf.dynamicreports.examples.gettingstarted;
 
+import net.sf.dynamicreports.examples.Templates;
 import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
+import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
 import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
+import net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
+import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
 import net.sf.dynamicreports.report.datasource.DRDataSource;
 import net.sf.dynamicreports.report.exception.DRException;
 import net.sf.jasperreports.engine.JRDataSource;
@@ -36,6 +40,7 @@ import java.math.BigDecimal;
 
 import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
+import static net.sf.dynamicreports.report.builder.DynamicReports.cnd;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
 import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
@@ -46,17 +51,17 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step08 class.</p>
+ * <p>SimpleReport_Step11 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step08 {
+public class SimpleReportStep11 {
 
     /**
-     * <p>Constructor for SimpleReport_Step08.</p>
+     * <p>Constructor for SimpleReport_Step11.</p>
      */
-    public SimpleReport_Step08() {
+    public SimpleReportStep11() {
         build();
     }
 
@@ -66,20 +71,23 @@ public class SimpleReport_Step08 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step08();
+        new SimpleReportStep11();
     }
 
     private void build() {
+        CurrencyType currencyType = new CurrencyType();
+
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
+        StyleBuilder titleStyle = stl.style(boldCenteredStyle).setVerticalTextAlignment(VerticalTextAlignment.MIDDLE).setFontSize(15);
 
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
@@ -88,6 +96,9 @@ public class SimpleReport_Step08 {
         Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         ColumnGroupBuilder itemGroup = grp.group(itemColumn);
         itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
+
+        ConditionalStyleBuilder condition1 = stl.conditionalStyle(cnd.greater(priceColumn, 150)).setBackgroundColor(new Color(210, 255, 210));
+        ConditionalStyleBuilder condition2 = stl.conditionalStyle(cnd.smaller(priceColumn, 30)).setBackgroundColor(new Color(255, 210, 210));
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
@@ -99,11 +110,18 @@ public class SimpleReport_Step08 {
                     .groupBy(itemGroup)
                     .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
-                    .title(cmp.text("Getting started").setStyle(boldCenteredStyle))// shows report title
+                    .detailRowHighlighters(condition1, condition2)
+                    .title(// shows report title
+                           cmp.horizontalList()
+                              .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
+                                   cmp.text("DynamicReports").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.LEFT),
+                                   cmp.text("Getting started").setStyle(titleStyle).setHorizontalTextAlignment(HorizontalTextAlignment.RIGHT))
+                              .newRow()
+                              .add(cmp.filler().setStyle(stl.style().setTopBorder(stl.pen2Point())).setFixedHeight(10)))
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
                     .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -120,5 +138,14 @@ public class SimpleReport_Step08 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
+    }
+
+    private class CurrencyType extends BigDecimalType {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getPattern() {
+            return "$ #,###.00";
+        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep12.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SimpleReportStep12.java
@@ -25,7 +25,9 @@ import net.sf.dynamicreports.examples.Templates;
 import net.sf.dynamicreports.report.builder.chart.Bar3DChartBuilder;
 import net.sf.dynamicreports.report.builder.column.PercentageColumnBuilder;
 import net.sf.dynamicreports.report.builder.column.TextColumnBuilder;
+import net.sf.dynamicreports.report.builder.datatype.BigDecimalType;
 import net.sf.dynamicreports.report.builder.group.ColumnGroupBuilder;
+import net.sf.dynamicreports.report.builder.style.ConditionalStyleBuilder;
 import net.sf.dynamicreports.report.builder.style.StyleBuilder;
 import net.sf.dynamicreports.report.constant.HorizontalTextAlignment;
 import net.sf.dynamicreports.report.constant.VerticalTextAlignment;
@@ -38,6 +40,7 @@ import java.math.BigDecimal;
 
 import static net.sf.dynamicreports.report.builder.DynamicReports.cht;
 import static net.sf.dynamicreports.report.builder.DynamicReports.cmp;
+import static net.sf.dynamicreports.report.builder.DynamicReports.cnd;
 import static net.sf.dynamicreports.report.builder.DynamicReports.col;
 import static net.sf.dynamicreports.report.builder.DynamicReports.exp;
 import static net.sf.dynamicreports.report.builder.DynamicReports.grid;
@@ -48,17 +51,17 @@ import static net.sf.dynamicreports.report.builder.DynamicReports.stl;
 import static net.sf.dynamicreports.report.builder.DynamicReports.type;
 
 /**
- * <p>SimpleReport_Step09 class.</p>
+ * <p>SimpleReport_Step12 class.</p>
  *
  * @author Ricardo Mariaca (r.mariaca@dynamicreports.org)
  * @version $Id: $Id
  */
-public class SimpleReport_Step09 {
+public class SimpleReportStep12 {
 
     /**
-     * <p>Constructor for SimpleReport_Step09.</p>
+     * <p>Constructor for SimpleReport_Step12.</p>
      */
-    public SimpleReport_Step09() {
+    public SimpleReportStep12() {
         build();
     }
 
@@ -68,10 +71,12 @@ public class SimpleReport_Step09 {
      * @param args an array of {@link java.lang.String} objects.
      */
     public static void main(String[] args) {
-        new SimpleReport_Step09();
+        new SimpleReportStep12();
     }
 
     private void build() {
+        CurrencyType currencyType = new CurrencyType();
+
         StyleBuilder boldStyle = stl.style().bold();
         StyleBuilder boldCenteredStyle = stl.style(boldStyle).setHorizontalTextAlignment(HorizontalTextAlignment.CENTER);
         StyleBuilder columnTitleStyle = stl.style(boldCenteredStyle).setBorder(stl.pen1Point()).setBackgroundColor(Color.LIGHT_GRAY);
@@ -80,9 +85,9 @@ public class SimpleReport_Step09 {
         // title, field name data type
         TextColumnBuilder<String> itemColumn = col.column("Item", "item", type.stringType()).setStyle(boldStyle);
         TextColumnBuilder<Integer> quantityColumn = col.column("Quantity", "quantity", type.integerType());
-        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", type.bigDecimalType());
+        TextColumnBuilder<BigDecimal> unitPriceColumn = col.column("Unit price", "unitprice", currencyType);
         // price = unitPrice * quantity
-        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price");
+        TextColumnBuilder<BigDecimal> priceColumn = unitPriceColumn.multiply(quantityColumn).setTitle("Price").setDataType(currencyType);
         PercentageColumnBuilder pricePercColumn = col.percentageColumn("Price %", priceColumn);
         TextColumnBuilder<Integer> rowNumberColumn = col.reportRowNumberColumn("No.")
                                                         // sets the fixed width of a column, width = 2 * character width
@@ -91,6 +96,13 @@ public class SimpleReport_Step09 {
         Bar3DChartBuilder itemChart2 = cht.bar3DChart().setTitle("Sales by item").setCategory(itemColumn).setUseSeriesAsCategory(true).addSerie(cht.serie(unitPriceColumn), cht.serie(priceColumn));
         ColumnGroupBuilder itemGroup = grp.group(itemColumn);
         itemGroup.setPrintSubtotalsWhenExpression(exp.printWhenGroupHasMoreThanOneRow(itemGroup));
+
+        ConditionalStyleBuilder condition1 = stl.conditionalStyle(cnd.greater(priceColumn, 150)).setBackgroundColor(new Color(210, 255, 210));
+        ConditionalStyleBuilder condition2 = stl.conditionalStyle(cnd.smaller(priceColumn, 30)).setBackgroundColor(new Color(255, 210, 210));
+        ConditionalStyleBuilder condition3 = stl.conditionalStyle(cnd.greater(priceColumn, 200)).setBackgroundColor(new Color(0, 190, 0)).bold();
+        ConditionalStyleBuilder condition4 = stl.conditionalStyle(cnd.smaller(priceColumn, 20)).setBackgroundColor(new Color(190, 0, 0)).bold();
+        StyleBuilder priceStyle = stl.style().conditionalStyles(condition3, condition4);
+        priceColumn.setStyle(priceStyle);
         try {
             report()// create new report design
                     .setColumnTitleStyle(columnTitleStyle)
@@ -102,6 +114,7 @@ public class SimpleReport_Step09 {
                     .groupBy(itemGroup)
                     .subtotalsAtSummary(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
                     .subtotalsAtFirstGroupFooter(sbt.sum(unitPriceColumn), sbt.sum(priceColumn))
+                    .detailRowHighlighters(condition1, condition2)
                     .title(// shows report title
                            cmp.horizontalList()
                               .add(cmp.image(Templates.class.getResource("images/dynamicreports.png")).setFixedDimension(80, 80),
@@ -112,7 +125,7 @@ public class SimpleReport_Step09 {
                     .pageFooter(cmp.pageXofY().setStyle(boldCenteredStyle))// shows number of page at page footer
                     .summary(cmp.horizontalList(itemChart, itemChart2))
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }
@@ -129,5 +142,14 @@ public class SimpleReport_Step09 {
         dataSource.add("Book", 5, BigDecimal.valueOf(10));
         dataSource.add("Book", 8, BigDecimal.valueOf(9));
         return dataSource;
+    }
+
+    private class CurrencyType extends BigDecimalType {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getPattern() {
+            return "$ #,###.00";
+        }
     }
 }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SubtotalReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/gettingstarted/SubtotalReport.java
@@ -92,7 +92,7 @@ public class SubtotalReport {
                     .subtotalsOfPercentageAtGroupFooter(columnGroup, createPercSubtotal("This is a group footer perc."))
 
                     .setDataSource(createDataSource())// set datasource
-                    .show();// create and show report
+                    .show(); // create and show report
         } catch (DRException e) {
             e.printStackTrace();
         }

--- a/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/miscellaneous/InheritanceReport.java
+++ b/dynamicreports-examples/src/main/java/net/sf/dynamicreports/examples/miscellaneous/InheritanceReport.java
@@ -80,6 +80,11 @@ public class InheritanceReport {
         return dataSource;
     }
 
+    /**
+     * Illustration purposes. This class remains non-final to illustrate the impact an inheritance-type report
+     * and as you can see it will be extended by ReportB. It is however expected that the user will have the
+     * wisdom to avoid creating non-final private classes.
+     */
     private class ReportA {
         protected JasperReportBuilder report = report();
 

--- a/dynamicreports-googlecharts/pom.xml
+++ b/dynamicreports-googlecharts/pom.xml
@@ -39,9 +39,104 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${sourceVersion}</source>
+                    <target>${targetVersion}</target>
+                    <encoding>${encoding}</encoding>
+                </configuration>
+            </plugin>
+            <!--Check for use of legacy code-->
+            <plugin>
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <!--Could run with mvn clean verify-->
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>run-checkstyle</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>module-info.java</excludes>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    <headerLocation>../src/etc/checkstyle.xml</headerLocation>
+                    <maxAllowedViolations>${checkstyle.config.maxAllowedViolations}</maxAllowedViolations>
+                    <configLocation>../src/etc/checkstyle.xml</configLocation>
+                    <consoleOutput>${checkstyle.config.consoleOutput}</consoleOutput>
+                    <failsOnError>${checkstyle.config.failsOnError}</failsOnError>
+                    <includeResources>${checkstyle.config.includeResources}</includeResources>
+                    <includeTestResources>${checkstyle.config.includeTestResources}</includeTestResources>
+                    <includeTestSourceDirectory>${checkstyle.config.includeTestSourceDirectory}</includeTestSourceDirectory>
+                    <linkXRef>${linkXRef}</linkXRef>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <!--// TODO Use javadoc from JAVA 10 to create searcheable javadocs-->
+                    <!--<javadocExecutable>${env.JAVA_10_HOME}\bin\javadoc.exe</javadocExecutable>-->
+                    <sourceFileExcludes>
+                        <sourceFileExclude>${project.basedir}/dynamicreports-core/target</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+            <!--//TODO fix "commandline was too long error"-->
+            <!--<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jdeps-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            &lt;!&ndash;<goal>jdkinternals</goal>&ndash;&gt; &lt;!&ndash; verify main classes &ndash;&gt;
+                            <goal>test-jdkinternals</goal> &lt;!&ndash; verify test classes &ndash;&gt;
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>-->
         </plugins>
     </build>
 

--- a/dynamicreports-googlecharts/src/main/java/net/sf/dynamicreports/googlecharts/jasper/GoogleChartsExtensionsRegistryFactory.java
+++ b/dynamicreports-googlecharts/src/main/java/net/sf/dynamicreports/googlecharts/jasper/GoogleChartsExtensionsRegistryFactory.java
@@ -84,7 +84,7 @@ public class GoogleChartsExtensionsRegistryFactory implements ExtensionsRegistry
 
         REGISTRY = new ExtensionsRegistry() {
             @Override
-            @SuppressWarnings( {"rawtypes", "unchecked"})
+            @SuppressWarnings({"rawtypes", "unchecked"})
             public List getExtensions(Class extensionType) {
                 if (ComponentsBundle.class.equals(extensionType)) {
                     return Collections.singletonList(bundle);

--- a/dynamicreports-googlecharts/src/main/java/net/sf/dynamicreports/googlecharts/jasper/geomap/GeoMapData.java
+++ b/dynamicreports-googlecharts/src/main/java/net/sf/dynamicreports/googlecharts/jasper/geomap/GeoMapData.java
@@ -96,4 +96,12 @@ public class GeoMapData {
         }
         return location.equals(((GeoMapData) obj).location);
     }
+
+    @Override
+    public int hashCode() {
+        int result = getLocation() != null ? getLocation().hashCode() : 0;
+        result = 31 * result + (getValue() != null ? getValue().hashCode() : 0);
+        result = 31 * result + (getLabel() != null ? getLabel().hashCode() : 0);
+        return result;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,8 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                            <doclint>none</doclint>
                             <nosince>false</nosince>
                             <failOnError>false</failOnError>
                             <doclint>none</doclint>
@@ -650,6 +652,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>java8-doclint-disabled</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
         </profile>
 
     </profiles>


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Fixed issues with the javadoc plugin during packaging and deployment

* **What is the current behavior?** (You can also link to an open issue here)
The doclint process of the new javadoc tool ( java 8+) conducts strict and vindictive HTML 4 validation checks failing the build. 
The tools is so pedantic that it will fail even code comments generated by the XJC tool.
This has caused failure in deployment according to [issue # 51](https://github.com/dynamicreports/dynamicreports/issues/51)

The checkstyle failures are also unfortunate and regretted since they are not supposed to have passed commit checks.


* **What is the new behavior (if this is a feature change)?**

Javadoc errors have to be fixed over a long period of time. Too many files have been affected and the time required to fix each file is not justifiable. 
So a new profile has been created to by-pass doclint.
As for the other checks, source, javadoc and even checkstyle plugins have been added to the build configuration itself. This will prevent commit checks from evading quality checks probably because certain profiles have been unchecked or otherwise. This will make the work of committers harder but it will reduce technical debt in the long run. For instance the code still contains hundreds of equal functions that are not accompanied by a hashcode function. Am sure this might be the reason a multitude of issues especially if anyone is using maps or lists. Checkstyle gives these incedents a pass because we configured these are warnings. In the next release I purpose to configure these are errors, purposely stopping all builds until they are all fixed.

* **Does this PR introduce a breaking change?**

There are no issues that have been identified for now. 
The committers will experience more stringent checks on typical commits but I cannot see any other changes affecting the users directly.