### PR TITLE
Travis-CI & Code-cov separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 
+#### Master
 [![Build Status](https://travis-ci.com/dynamicreports/dynamicreports.svg?branch=master)](https://travis-ci.com/dynamicreports/dynamicreports)
-[![Build Status](https://travis-ci.com/dynamicreports/dynamicreports.svg?branch=development)](https://travis-ci.com/dynamicreports/dynamicreports)
 [![codecov](https://codecov.io/gh/dynamicreports/dynamicreports/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamicreports/dynamicreports)
+
+#### Development
+[![Build Status](https://travis-ci.com/dynamicreports/dynamicreports.svg?branch=development)](https://travis-ci.com/dynamicreports/dynamicreports)
 [![codecov](https://codecov.io/gh/dynamicreports/dynamicreports/branch/development/graph/badge.svg)](https://codecov.io/gh/dynamicreports/dynamicreports)
 
 # Dynamic Reports


### PR DESCRIPTION
This way it is easier to understand the meaning of the badges in the Readme file.
In the old format I couldn't get the reason of duplicate badges.

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It is an update of the readme file to make clear the correspondence of the Travis-CI & Code-Cov badges to the Master and Development branches.


* **What is the current behavior?** (You can also link to an open issue here)
The Travis & Code-Cov badges are displayed one after the other on the same line and it is not clear the link to the Master or Development branch.


* **What is the new behavior (if this is a feature change)?**
The Travis & Code-Cov badges are displayed on separate lines under the name of the corresponding branch, this way it is clear the correspondence between the badges and the linked branch.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
